### PR TITLE
Add NanScope to fix crash with node-webkit/x86_64

### DIFF
--- a/src/serialport_poller.cpp
+++ b/src/serialport_poller.cpp
@@ -23,6 +23,7 @@ void _serialportReadable(uv_poll_t *req, int status, int events) {
 }
 
 void SerialportPoller::callCallback(int status) {
+  NanScope();
   // uv_work_t* req = new uv_work_t;
 
   // Call the callback to go read more data...


### PR DESCRIPTION
With node-webkit 0.11.5 running on Ubuntu 14.04.1 x86_64,
SerialportPoller::callCallback would exit with V8 error: Cannot create a
handle without a HandleScope. This occurred when constructing the
v8::Handle for argv[1]. Adding a NanScope() to the top of the function
resolves the issue.

This may be related to voodootikigod/node-serialport#379, but it's not
clear from the bug report.