### PR TITLE
Removed console.log's

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -397,13 +397,13 @@ function SerialPortFactory() {
     try {
       factory.SerialPortBinding.close(fd, function (err) {
         if (err) {
-          console.log('Disconnect completed with error:' + err);
+          // console.log('Disconnect completed with error:' + err);
         } else {
-          console.log('Disconnect completed');
+          // console.log('Disconnect completed');
         }
       });
     } catch (e) {
-      console.log('Disconnect failed with exception', e);
+      // console.log('Disconnect failed with exception', e);
     }
 
     self.removeAllListeners();


### PR DESCRIPTION
Logging should be part of the library user, not the library itself.

Perhaps its a good idea to use the debug library instead?