### PR TITLE
need a test to see that open event was fired

### DIFF
--- a/test/serialport-basic.js
+++ b/test/serialport-basic.js
@@ -31,6 +31,13 @@ describe('SerialPort', function () {
       });
     });
 
+    it('emits the open event', function (done) {
+      var port = new SerialPort('/dev/exists');
+      port.on('open', function(){
+        done();
+      });
+    });
+
     it('emits an error on the factory when erroring without a callback', function (done) {
       // finish the test on error
       MockedSerialPort.once('error', function (err) {


### PR DESCRIPTION
Ran into this on 2 of my node-serialport implementations so back porting it.