### PR TITLE
Add BREAK command, useful for CISCO router to break into rommon

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -663,6 +663,35 @@ function SerialPortFactory() {
     });
   };
 
+  SerialPort.prototype.break = function (callback) {
+    var self = this;
+    var fd = this.fd;
+
+    if (!fd) {
+      var err = new Error('Serialport not open.');
+      if (callback) {
+        callback(err);
+      } else {
+        self.emit('error', err);
+      }
+      return;
+    }
+
+    factory.SerialPortBinding.break(fd, function (err, result) {
+      if (err) {
+        if (callback) {
+          callback(err, result);
+        } else {
+          self.emit('error', err);
+        }
+      } else {
+        if (callback) {
+          callback(err, result);
+        }
+      }
+    });
+  };
+
   factory.SerialPort = SerialPort;
   factory.parsers = parsers;
   factory.SerialPortBinding = SerialPortBinding;

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -565,6 +565,56 @@ void EIO_AfterDrain(uv_work_t* req) {
   delete req;
 }
 
+NAN_METHOD(Break) {
+  NanScope();
+
+  // file descriptor
+  if(!args[0]->IsInt32()) {
+    NanThrowTypeError("First argument must be an int");
+    NanReturnUndefined();
+  }
+  int fd = args[0]->ToInt32()->Int32Value();
+
+  // callback
+  if(!args[1]->IsFunction()) {
+    NanThrowTypeError("Second argument must be a function");
+    NanReturnUndefined();
+  }
+  v8::Local<v8::Function> callback = args[1].As<v8::Function>();
+
+  BreakBaton* baton = new BreakBaton();
+  memset(baton, 0, sizeof(BreakBaton));
+  baton->fd = fd;
+  baton->callback = new NanCallback(callback);
+
+  uv_work_t* req = new uv_work_t();
+  req->data = baton;
+  uv_queue_work(uv_default_loop(), req, EIO_Break, (uv_after_work_cb)EIO_AfterBreak);
+
+  NanReturnUndefined();
+}
+
+void EIO_AfterBreak(uv_work_t* req) {
+  NanScope();
+
+  BreakBaton* data = static_cast<BreakBaton*>(req->data);
+
+  v8::Handle<v8::Value> argv[2];
+
+  if(data->errorString[0]) {
+    argv[0] = v8::Exception::Error(NanNew<v8::String>(data->errorString));
+    argv[1] = NanUndefined();
+  } else {
+    argv[0] = NanUndefined();
+    argv[1] = NanNew<v8::Int32>(data->result);
+  }
+  data->callback->Call(2, argv);
+
+  delete data->callback;
+  delete data;
+  delete req;
+}
+
 // Change request for ticket #401 - credit to @sguilly
 SerialPortParity NAN_INLINE(ToParityEnum(const v8::Handle<v8::String>& v8str)) {
   NanScope();
@@ -608,6 +658,7 @@ extern "C" {
     NODE_SET_METHOD(target, "list", List);
     NODE_SET_METHOD(target, "flush", Flush);
     NODE_SET_METHOD(target, "drain", Drain);
+    NODE_SET_METHOD(target, "break", Break);
 
 #ifndef WIN32
     SerialportPoller::Init(target);

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -54,6 +54,10 @@ NAN_METHOD(Drain);
 void EIO_Drain(uv_work_t* req);
 void EIO_AfterDrain(uv_work_t* req);
 
+NAN_METHOD(Break);
+void EIO_Break(uv_work_t* req);
+void EIO_AfterBreak(uv_work_t* req);
+
 SerialPortParity ToParityEnum(const v8::Handle<v8::String>& str);
 SerialPortStopBits ToStopBitEnum(double stopBits);
 
@@ -183,6 +187,14 @@ public:
 };
 
 struct DrainBaton {
+public:
+  int fd;
+  NanCallback* callback;
+  int result;
+  char errorString[ERROR_STRING_SIZE];
+};
+
+struct BreakBaton {
 public:
   int fd;
   NanCallback* callback;

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -738,4 +738,13 @@ void EIO_Drain(uv_work_t* req) {
   data->result = tcdrain(data->fd);
 }
 
+void EIO_Break(uv_work_t* req) {
+  BreakBaton* data = static_cast<BreakBaton*>(req->data);
+
+  data->result = tcsendbreak(data->fd, 1000);
+  if (data->result == -1) {
+    snprintf(data->errorString, sizeof(data->errorString), "Error %s calling ioctl( ..., tcsendbreak)", strerror(errno));
+  }
+}
+
 #endif


### PR DESCRIPTION
Hi,

I work with Cisco routers. When I would like to break the boot process and switch to rommon mode, I need to send BREAK signal on the serial line. This command is missing in node-serialport, so I added it.

Kind Regards,
