### PR TITLE
Update installation instructions for Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ npm install serialport
  * Download and install node.js:
 
 ```bash
-   wget http://nodejs.org/dist/v0.10.12/node-v0.10.12-linux-arm-pi.tar.gz
-   tar xvfz node-v0.10.12-linux-arm-pi.tar.gz
-   sudo mv node-v0.10.12-linux-arm-pi /opt/node/
+   wget http://nodejs.org/dist/v0.10.16/node-v0.10.16-linux-arm-pi.tar.gz
+   tar xvfz node-v0.10.16-linux-arm-pi.tar.gz
+   sudo mv node-v0.10.16-linux-arm-pi /opt/node/
 ```
 
  * Set up your paths correctly:


### PR DESCRIPTION
The current instructions make users install node v0.10.12. This version of node (or rather the bundled version of npm) is incompatible with serialport's package.json.

People (including me) struggle to install serialport on their raspberry pi, see #469 and #489.

I tried with node v0.10.16 and installation works for me.
