### PR TITLE
Added hang up on close option to constructor.

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -65,6 +65,7 @@ function SerialPortFactory(_spfOptions) {
     xon: false,
     xoff: false,
     xany: false,
+    hupcl:true,
     rts: true,
     cts: false,
     dtr: true,
@@ -170,6 +171,8 @@ function SerialPortFactory(_spfOptions) {
         }
       }
     }
+
+    options.hupcl = (typeof options.hupcl === 'boolean') ? options.hupcl : _options.hupcl;
 
     options.bufferSize = options.bufferSize || options.buffersize || _options.buffersize;
     options.parser = options.parser || _options.parser;

--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -122,6 +122,7 @@ NAN_METHOD(Open) {
   baton->xon = options->Get(NanNew<v8::String>("xon"))->ToBoolean()->BooleanValue();
   baton->xoff = options->Get(NanNew<v8::String>("xoff"))->ToBoolean()->BooleanValue();
   baton->xany = options->Get(NanNew<v8::String>("xany"))->ToBoolean()->BooleanValue();
+  baton->hupcl = options->Get(NanNew<v8::String>("hupcl"))->ToBoolean()->BooleanValue();
 
   v8::Local<v8::Object> platformOptions = options->Get(NanNew<v8::String>("platformOptions"))->ToObject();
   baton->platformOptions = ParsePlatformOptions(platformOptions);

--- a/src/serialport.h
+++ b/src/serialport.h
@@ -78,9 +78,10 @@ public:
   bool xoff;
   bool xany;
   bool dsrdtr;
+  bool hupcl;
   SerialPortParity parity;
   SerialPortStopBits stopBits;
-  OpenBatonPlatformOptions* platformOptions;  
+  OpenBatonPlatformOptions* platformOptions;
   char errorString[ERROR_STRING_SIZE];
 };
 

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -148,6 +148,8 @@ void EIO_Open(uv_work_t* req) {
 
 
   int flags = (O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC | O_SYNC);
+  if(data->hupcl == false)
+      flags &= ~HUPCL;
   int fd = open(data->path, flags);
 
   if (fd == -1) {

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -80,6 +80,8 @@ void EIO_Open(uv_work_t* req) {
 
   DCB dcb = { 0 };
   dcb.DCBlength = sizeof(DCB);
+  if(data->hupcl == false)
+      dcb.fDtrControl = DTR_CONTROL_DISABLE; // disable DTR to avoid reset
   if(!BuildCommDCB("9600,n,8,1", &dcb)) {
     ErrorCodeToString("BuildCommDCB", GetLastError(), data->errorString);
     return;
@@ -189,7 +191,7 @@ void EIO_Set(uv_work_t* req) {
   GetCommMask((HANDLE)data->fd, &bits);
 
   bits &= ~( EV_CTS | EV_DSR);
-  
+
   if (data->cts) {
     bits |= EV_CTS;
   }


### PR DESCRIPTION
When hupcl is set to false in the constructor it stops the assertion of DTR on serial port open. This effectively disables resetting of the arduino on serial port open.