### PR TITLE
test explcitly for node 10, hacky fix for #492

### DIFF
--- a/test/serialport-c.js
+++ b/test/serialport-c.js
@@ -17,7 +17,7 @@ describe('SerialPort', function () {
 
 
   describe('Initialization', function () {
-    if (process.version.indexOf('v0.11.') ===0) {
+    if (process.version.indexOf('v0.10.') !==0) {
       it('does not currently work due to an issue with node unstable release, works in master.', function (done) {
         done();
       });


### PR DESCRIPTION
Hacky fix, but it was already hacky sooo...?? Instead of testing for === 11 test for not equal 10, which is apparently only where that test works?