### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ Opens a connection to the given serial port.
 
 Called when a connection has been opened. NOTE: Will NOT be called if openImmediately is set to false as open will not be performed. The callback should be a function that looks like: `function (error) { ... }`
 
+### .isOpen()
+
+Returns `true` if the port is open.
+
 ### .write (buffer, callback)
 
 Writes data to the given serial port.


### PR DESCRIPTION
The isOpen method was originally proposed to be added as part of https://github.com/voodootikigod/node-serialport/pull/387 but was never merged.  That original PR had updated the README as part of it, but when the isOpen was actually added later ( https://github.com/voodootikigod/node-serialport/commit/21a076ae6867bd3255aa62b4658d4395a2cd1ee4 ), the docs were never updated.