### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "serialportlist": "./bin/serialportList.js",
     "serialportterm": "./bin/serialportTerminal.js"
   },
+  "license": "MIT",
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",
     "test": "grunt --verbose"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/