### PR TITLE
Added missing setQueryPortsByPath function.

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -708,6 +708,12 @@ function SerialPortFactory(_spfOptions) {
   factory.parsers = parsers;
   factory.SerialPortBinding = SerialPortBinding;
 
+  factory.setQueryPortsByPath=function(val)
+  {
+	spfOptions.queryPortsByPath=val;
+  }
+
+
   if (process.platform === 'win32') {
     factory.list = SerialPortBinding.list;
   } else if (process.platform === 'darwin') {


### PR DESCRIPTION
It seem that without setting queryPortsByPath there is no way to see multiple duplicate devices on Linux.

Example with queryPortsByPath=false (default) set:
```
comName /dev/ttyUSB1
pnpId usb-FTDI_FT232R_USB_UART_if00-port0
manufacturer FTDI
```

Example with queryPortsByPath=true set:
```
comName /dev/ttyUSB0
pnpId usb-FTDI_FT232R_USB_UART_if00-port0
manufacturer FTDI
Found
comName /dev/ttyUSB1
pnpId usb-FTDI_FT232R_USB_UART_if00-port0
manufacturer FTDI
Found
```

Am I correct to assume that a function like this is missing?
```
  factory.setQueryPortsByPath=function(val)
  {
	spfOptions.queryPortsByPath=val;
  }
```

Then this works:
```
serialPort.setQueryPortsByPath(true);
serialPort.list(function (err, ports) {
...
});
```