### PR TITLE
Add node.js v0.11 as build target for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: objective-c
 env:
   matrix:
     - export NODE_VERSION="0.10"
+    - export NODE_VERSION="0.11"
     - export NODE_VERSION="0.12"
   global:
     - secure: "Zg7w8hTpgVfm6JeTScsMhaexFcVS5N2oI9O/6MLtsm3CUhb0Txq65y4y/a5DU3re6Pl1ryE21anVLdg4RGDeykCauQtg8nFzuGXBfNn9bRTnsIfkiS9LNkbSZ8h3c7EsyX0NJ7LVgnkPh/XXMqMj4Nh0ovbBCwZJ6k2ZvccvDvU="


### PR DESCRIPTION
Related to #526 and #527.