### PR TITLE
Expose `SerialPortFactory` method

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -707,6 +707,7 @@ function SerialPortFactory(_spfOptions) {
   factory.SerialPort = SerialPort;
   factory.parsers = parsers;
   factory.SerialPortBinding = SerialPortBinding;
+  factory.SerialPortFactory = SerialPortFactory;
 
   if (process.platform === 'win32') {
     factory.list = SerialPortBinding.list;


### PR DESCRIPTION
Addresses issue #575 

Allows the user to manually instantiate a new `SerialPortFactory`,
including an options object. Does not break backwards-compatibility.

Usage example:

```js
var serial = require('serialport'),
    serial = new serial.SerialPortFactory({ 'queryPortsByPath': true });
```

Querying ports by path is desireable when there is a need to interact
with multiple identical serial devices.