### PR TITLE
Triggering garbage collection less frequently

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,15 +54,16 @@
     "node-pre-gyp"
   ],
   "devDependencies": {
-    "mocha": "*",
-    "chai": "*",
-    "sinon-chai": "*",
-    "sinon": "*",
+    "chai": "^3.2.0",
+    "debug": "^2.2.0",
     "grunt": "*",
     "grunt-cli": "*",
-    "grunt-mocha-test": "*",
-    "grunt-contrib-jshint": "*",
-    "sandboxed-module": "~0.3.0"
+    "grunt-contrib-jshint": "^0.11.3",
+    "grunt-mocha-test": "^0.12.7",
+    "mocha": "^2.3.2",
+    "sandboxed-module": "^2.0.3",
+    "sinon": "^1.16.1",
+    "sinon-chai": "^2.8.0"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/serialport.js
+++ b/serialport.js
@@ -293,7 +293,7 @@ function SerialPortFactory(_spfOptions) {
     } else {
       if (err) {
         // console.log("write");
-        self.emit('error', err);
+        this.emit('error', err);
       }
     }
   };
@@ -347,7 +347,7 @@ function SerialPortFactory(_spfOptions) {
 
         // do not emit events if the stream is paused
         if (this.paused) {
-          this.buffer = Buffer.concat([self.buffer, b]);
+          this.buffer = Buffer.concat([this.buffer, b]);
           return;
         } else {
           this._emitData(b);

--- a/serialport.js
+++ b/serialport.js
@@ -281,6 +281,17 @@ function SerialPortFactory(_spfOptions) {
     return (this.fd ? true : false);
   };
 
+  SerialPort.prototype.writeHandler = function (err, results) {
+    if (this.callback) {
+      this.callback(err, results);
+    } else {
+      if (err) {
+        // console.log("write");
+        self.emit('error', err);
+      }
+    }
+  };
+
   SerialPort.prototype.write = function (buffer, callback) {
     var self = this;
     if (!this.fd) {
@@ -298,17 +309,8 @@ function SerialPortFactory(_spfOptions) {
     if (!Buffer.isBuffer(buffer)) {
       buffer = new Buffer(buffer);
     }
-    debug('Write: '+JSON.stringify(buffer));
-    factory.SerialPortBinding.write(this.fd, buffer, function (err, results) {
-      if (callback) {
-        callback(err, results);
-      } else {
-        if (err) {
-          // console.log("write");
-          self.emit('error', err);
-        }
-      }
-    });
+    this.callback = callback;
+    factory.SerialPortBinding.write(this.fd, buffer, SerialPort.prototype.writeHandler);
   };
 
   if (process.platform !== 'win32') {


### PR DESCRIPTION
My project is writing to an Arduino over the serial port 50 times per second, which is causing garbage collection to get triggered every 30 seconds or so when running on a Raspberry Pi. This ends up locking up the RPi for the duration of gc.

node-serialport.read() and .write() use inline functions in the standard js way, which unfortunately reallocates their memory every time. See "1) Pull inner functions...into longer lived scope" in http://stackoverflow.com/a/18411275.

In my example, after this change memory allocation on the heap went from ~150kB over 10s to ~10kB.