### PR TITLE
Bugfix/file descriptor 0

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -249,7 +249,7 @@ function SerialPortFactory(_spfOptions) {
   //verification code above
   SerialPort.prototype.update = function (options, callback) {
     var self = this;
-    if (!this.fd) {
+    if (this.fd === null) {
       debug('Update attempted, but serialport not available - FD is not set');
       var err = new Error('Serialport not open.');
       if (callback) {
@@ -278,12 +278,12 @@ function SerialPortFactory(_spfOptions) {
   };
 
   SerialPort.prototype.isOpen = function() {
-    return (this.fd ? true : false);
+    return this.fd !== null;
   };
 
   SerialPort.prototype.write = function (buffer, callback) {
     var self = this;
-    if (!this.fd) {
+    if (this.fd === null) {
       debug('Write attempted, but serialport not available - FD is not set');
       var err = new Error('Serialport not open.');
       if (callback) {
@@ -454,7 +454,7 @@ function SerialPortFactory(_spfOptions) {
 
     self.removeAllListeners();
     self.closing = false;
-    self.fd = 0;
+    self.fd = null;
 
     if (process.platform !== 'win32') {
       self.readable = false;
@@ -472,7 +472,7 @@ function SerialPortFactory(_spfOptions) {
     if (self.closing) {
       return;
     }
-    if (!fd) {
+    if (fd === null) {
       var err = new Error('Serialport not open.');
       if (callback) {
         callback(err);
@@ -507,7 +507,7 @@ function SerialPortFactory(_spfOptions) {
         self.emit('close');
         self.removeAllListeners();
         self.closing = false;
-        self.fd = 0;
+        self.fd = null;
 
         if (callback) {
           callback();
@@ -603,7 +603,7 @@ function SerialPortFactory(_spfOptions) {
     var self = this;
     var fd = self.fd;
 
-    if (!fd) {
+    if (fd === null) {
       var err = new Error('Serialport not open.');
       if (callback) {
         callback(err);
@@ -652,7 +652,7 @@ function SerialPortFactory(_spfOptions) {
       options.brk = _options.brk;
     }
 
-    if (!fd) {
+    if (fd === null) {
       var err = new Error('Serialport not open.');
       if (callback) {
         callback(err);
@@ -679,7 +679,7 @@ function SerialPortFactory(_spfOptions) {
     var self = this;
     var fd = this.fd;
 
-    if (!fd) {
+    if (fd === null) {
       var err = new Error('Serialport not open.');
       if (callback) {
         callback(err);

--- a/test/serialport-basic.js
+++ b/test/serialport-basic.js
@@ -150,6 +150,56 @@ describe('SerialPort', function () {
       });
     });
 
+    it('write should consider 0 to be a valid fd', function(done) {
+      var port = new SerialPort('/dev/exists', function() {
+        expect(port.fd).to.equal(0);
+        port.write(new Buffer(0), done);
+      });
+    });
+
+    it('flush should consider 0 to be a valid fd', function(done) {
+      var port = new SerialPort('/dev/exists', function() {
+        expect(port.fd).to.equal(0);
+        port.flush(done);
+      });
+    });
+
+    it('set should consider 0 to be a valid fd', function(done) {
+      var port = new SerialPort('/dev/exists', function() {
+        expect(port.fd).to.equal(0);
+        port.set({}, done);
+      });
+    });
+
+    it('drain should consider 0 to be a valid fd', function(done) {
+      var port = new SerialPort('/dev/exists', function() {
+        expect(port.fd).to.equal(0);
+        port.drain(done);
+      });
+    });
+
+    it('disconnected reset fd to null', function(done) {
+      var port = new SerialPort('/dev/exists', function () {
+        expect(port.fd).to.equal(0);
+        port.disconnected();
+        expect(port.fd).to.be.null;
+        done();
+      });
+    });
+
+    it('update should consider 0 a valid file descriptor', function() {
+      var port = new SerialPort('/dev/exists', function(done) {
+        expect(port.fd).to.equal(0);
+        port.update({}, done);
+      });
+    });
+
+    it('isOpen should consider 0 a valid file descriptor', function() {
+      var port = new SerialPort('/dev/exists', function(done) {
+        expect(port.fd).to.equal(0);
+        expect(port.isOpen()).to.be.true;
+      });
+    });
   });
 
   describe('reading data', function () {
@@ -245,6 +295,16 @@ describe('SerialPort', function () {
           done();
         });
         port.close();
+      });
+    });
+
+    it('should consider 0 a valid fd', function(done) {
+      var port = new SerialPort('/dev/exists', function() {
+        expect(port.fd).to.equal(0);
+        port.close(function () {
+          expect(port.fd).to.be.null;
+          done();
+        });
       });
     });
   });

--- a/test_mocks/linux-hardware.js
+++ b/test_mocks/linux-hardware.js
@@ -3,10 +3,10 @@
 "use strict";
 
 var mockSerialportPoller = function (hardware) {
-  var Poller = function (path, cb) {
-    this.port = hardware.ports[path];
+  var Poller = function (fd, cb) {
+    this.port = hardware.fds[fd];
     if (!this.port) {
-      throw new Error(path + " does not exist - please call hardware.createPort(path) first");
+      throw new Error(fd + " does not exist - please call hardware.createPort(path) first");
     }
     this.port.poller = this;
     this.polling = null;
@@ -25,6 +25,9 @@ var mockSerialportPoller = function (hardware) {
 };
 
 var Hardware = function () {
+  // We start at 1 because there are bugs when the fd is 0
+  this.nextFd = 1;
+  this.fds = {};
   this.ports = {};
   this.mockBinding = {
     list: this.list.bind(this),
@@ -38,9 +41,16 @@ var Hardware = function () {
 
 Hardware.prototype.reset = function () {
   this.ports = {};
+  this.fds = {};
+  // TODO Change to zero once 0-fd bug is fixed
+  this.nextFd = 1;
 };
 
 Hardware.prototype.createPort = function (path) {
+  if (this.ports[path]) {
+    delete this.fds[this.ports[path].fd];
+  }
+  var fd = this.nextFd++;
   this.ports[path] = {
     data: new Buffer(0),
     lastWrite: null,
@@ -54,8 +64,10 @@ Hardware.prototype.createPort = function (path) {
       locationId: '',
       vendorId: '',
       productId: ''
-    }
+    },
+    fd: fd
   };
+  this.fds[fd] = this.ports[path];
 };
 
 Hardware.prototype.emitData = function (path, data) {
@@ -90,39 +102,39 @@ Hardware.prototype.open = function (path, opt, cb) {
   }
   port.open = true;
   port.openOpt = opt;
-  cb && cb(null, path); // using path as the fd for convience
+  cb && cb(null, port.fd);
 };
 
-Hardware.prototype.write = function (path, buffer, cb) {
-  var port = this.ports[path];
+Hardware.prototype.write = function (fd, buffer, cb) {
+  var port = this.fds[fd];
   if (!port) {
-    return cb(new Error(path + " does not exist - please call hardware.createPort(path) first"));
+    return cb(new Error(fd + " does not exist - please call hardware.createPort(path) first"));
   }
   port.lastWrite = new Buffer(buffer); //copy
   cb && cb(null, buffer.length);
 };
 
-Hardware.prototype.close = function (path, cb) {
-  var port = this.ports[path];
+Hardware.prototype.close = function (fd, cb) {
+  var port = this.fds[fd];
   if (!port) {
-    return cb(new Error(path + " does not exist - please call hardware.createPort(path) first"));
+    return cb(new Error(fd + " does not exist - please call hardware.createPort(path) first"));
   }
   port.open = false;
   cb && cb(null);
 };
 
-Hardware.prototype.flush = function (path, cb) {
-  var port = this.ports[path];
+Hardware.prototype.flush = function (fd, cb) {
+  var port = this.fds[fd];
   if (!port) {
-    return cb(new Error(path + " does not exist - please call hardware.createPort(path) first"));
+    return cb(new Error(fd + " does not exist - please call hardware.createPort(path) first"));
   }
   cb && cb(null, undefined);
 };
 
-Hardware.prototype.fakeRead = function (path, buffer, offset, length, position, cb) {
-  var port = this.ports[path];
+Hardware.prototype.fakeRead = function (fd, buffer, offset, length, position, cb) {
+  var port = this.fds[fd];
   if (!port) {
-    return cb(new Error(path + " does not exist - please call hardware.createPort(path) first"));
+    return cb(new Error(fd + " does not exist - please call hardware.createPort(path) first"));
   }
   if (port.data.length === 0) {
     return cb(null, 0, buffer);

--- a/test_mocks/linux-hardware.js
+++ b/test_mocks/linux-hardware.js
@@ -25,16 +25,18 @@ var mockSerialportPoller = function (hardware) {
 };
 
 var Hardware = function () {
-  // We start at 1 because there are bugs when the fd is 0
-  this.nextFd = 1;
+  this.nextFd = 0;
   this.fds = {};
   this.ports = {};
   this.mockBinding = {
     list: this.list.bind(this),
     open: this.open.bind(this),
+    update: this.update.bind(this),
     write: this.write.bind(this),
     close: this.close.bind(this),
     flush: this.flush.bind(this),
+    set: this.set.bind(this),
+    drain: this.drain.bind(this),
     SerialportPoller: mockSerialportPoller(this)
   };
 };
@@ -42,8 +44,7 @@ var Hardware = function () {
 Hardware.prototype.reset = function () {
   this.ports = {};
   this.fds = {};
-  // TODO Change to zero once 0-fd bug is fixed
-  this.nextFd = 1;
+  this.nextFd = 0;
 };
 
 Hardware.prototype.createPort = function (path) {
@@ -105,6 +106,14 @@ Hardware.prototype.open = function (path, opt, cb) {
   cb && cb(null, port.fd);
 };
 
+Hardware.prototype.update = function(fd, opt, cb) {
+  var port = this.fds[fd];
+  if (!port) {
+    return cb(new Error(fd + " does not exist - please call hardware.createPort(path) first"));
+  }
+  cb && cb();
+};
+
 Hardware.prototype.write = function (fd, buffer, cb) {
   var port = this.fds[fd];
   if (!port) {
@@ -124,6 +133,22 @@ Hardware.prototype.close = function (fd, cb) {
 };
 
 Hardware.prototype.flush = function (fd, cb) {
+  var port = this.fds[fd];
+  if (!port) {
+    return cb(new Error(fd + " does not exist - please call hardware.createPort(path) first"));
+  }
+  cb && cb(null, undefined);
+};
+
+Hardware.prototype.set = function (fd, options, cb) {
+  var port = this.fds[fd];
+  if (!port) {
+    return cb(new Error(fd + " does not exist - please call hardware.createPort(path) first"));
+  }
+  cb && cb(null, undefined);
+};
+
+Hardware.prototype.drain = function (fd, cb) {
   var port = this.fds[fd];
   if (!port) {
     return cb(new Error(fd + " does not exist - please call hardware.createPort(path) first"));


### PR DESCRIPTION
This is a patch that fixes the issue where file descriptor 0 is considered invalid (issue #472).

The tests does not explicitly define the fd to be 0, instead I use an expect in the test itself. If you feel this is inadequate I can change the tests to stub the open call to always return fd 0 for those tests.