### PR TITLE
added new serial duplex test with no dependencies other than node-serialport

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ npm install serialport
  * Download and install node.js:
 
 ```bash
-   wget http://node-arm.herokuapp.com/node_latest_armhf.deb
-   sudo dpkg -i node_latest_armhf.deb
+   wget https://node-arm.herokuapp.com/node_archive_armhf.deb
+   sudo dpkg -i node_archive_armhf.deb
 ```
 
 More information can be found at [node-arm](http://node-arm.herokuapp.com/).

--- a/arduinoTest/serialDuplexTest.js
+++ b/arduinoTest/serialDuplexTest.js
@@ -1,0 +1,60 @@
+/*
+serialDuplexTest.js
+
+Tests the functtionality of the serial port library.
+To be used in conjunction with the Arduino sketch called ArduinoEcho.ino
+
+created 1 Oct  2015
+by Tom Igoe
+
+*/
+
+
+// serial port initialization:
+var serialport = require('serialport'),		// include the serialport library
+SerialPort  = serialport.SerialPort,			// make a local instance of serial
+portName = process.argv[2],								// get the port name from the command line
+portConfig = {
+	baudRate: 115200												// set data rate at 115200bps
+};
+
+var output = 32;													// ASCII space; lowest printable character
+var byteCount = 0;												// number of bytes read
+// open the serial port:
+var myPort = new SerialPort(portName, portConfig);
+
+myPort.on('open', openPort);			// called when the serial port opens
+myPort.on('data', receiveData);		// called when data comes in
+myPort.on('close', closePort);		// called when the serial port closes
+myPort.on('error', serialError);	// called when there's an error with the serial port
+
+function openPort() {
+	console.log('port open');
+	console.log('baud rate: ' + myPort.options.baudRate);
+	outString = String.fromCharCode(output);
+	console.log("String is: " + outString);
+	myPort.write(outString);
+}
+
+function receiveData(data) {
+	if (output <= 126) {				// highest printable character: ASCII ~
+		output++;
+	} else {
+		output = 32;							// lowest printable character: space
+	}
+	console.log('received: ' + data);
+	console.log('Byte count: ' + byteCount);
+	byteCount++;
+	outString = String.fromCharCode(output);
+	myPort.write(outString);
+	console.log("Sent: " + outString);
+}
+
+function closePort() {
+	console.log('port closed');
+}
+
+function serialError(error) {
+	console.log('there was an error with the serial port: ' + error);
+	myPort.close();
+}


### PR DESCRIPTION
This test works with the ArduinoEcho.ino sketch. It runs well as long as
the remote device is sending reasonably infrequently (a few bytes every
10ms, for example). But when the remote device is sending constantly
(comment out the delay in arduinoEcho.ino), this will stop at 852 bytes.
I have yet to determine a cause for this. Buffer overflow, perhaps?