### PR TITLE
add listing support for el capitan

### DIFF
--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -459,16 +459,23 @@ static io_service_t GetUsbDevice(io_service_t service)
   if (status == kIOReturnSuccess)
   {
     io_service_t currentService;
-    while ((currentService = IOIteratorNext(iterator)))
+    while ((currentService = IOIteratorNext(iterator)) && device == 0)
     {
       io_name_t serviceName;
       status = IORegistryEntryGetNameInPlane(currentService, kIOServicePlane, serviceName);
-      if (status == kIOReturnSuccess && (IOObjectConformsTo(currentService, kIOUSBDeviceClassName))) {
+      if (status == kIOReturnSuccess && IOObjectConformsTo(currentService, kIOUSBDeviceClassName)) {
         device = currentService;
-        break;
+      }
+      else {
+        // Release the service object which is no longer needed
+        (void) IOObjectRelease(currentService);
       }
     }
+
+    // Release the iterator
+    (void) IOObjectRelease(iterator);
   }
+
   return device;
 }
 

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -420,7 +420,7 @@ void EIO_Close(uv_work_t* req) {
 
 // Function prototypes
 static kern_return_t FindModems(io_iterator_t *matchingServices);
-static io_registry_entry_t GetUsbDevice(char *pathName);
+static io_service_t GetUsbDevice(io_service_t service);
 static stDeviceListItem* GetSerialDevices();
 
 
@@ -441,56 +441,35 @@ static kern_return_t FindModems(io_iterator_t *matchingServices)
     return kernResult;
 }
 
-static io_registry_entry_t GetUsbDevice(char* pathName)
+static io_service_t GetUsbDevice(io_service_t service)
 {
-    io_registry_entry_t device = 0;
+  IOReturn status;
+  io_iterator_t   iterator = 0;
+  io_service_t    device = 0;
 
-    CFMutableDictionaryRef classesToMatch = IOServiceMatching(kIOUSBDeviceClassName);
-    if (classesToMatch != NULL)
-    {
-        io_iterator_t matchingServices;
-        kern_return_t kernResult = IOServiceGetMatchingServices(kIOMasterPortDefault, classesToMatch, &matchingServices);
-        if (KERN_SUCCESS == kernResult)
-        {
-            io_service_t service;
-            Boolean deviceFound = false;
-
-            while ((service = IOIteratorNext(matchingServices)) && !deviceFound)
-            {
-                CFStringRef bsdPathAsCFString = (CFStringRef) IORegistryEntrySearchCFProperty(service, kIOServicePlane, CFSTR(kIOCalloutDeviceKey), kCFAllocatorDefault, kIORegistryIterateRecursively);
-
-                if (bsdPathAsCFString)
-                {
-                    Boolean result;
-                    char    bsdPath[MAXPATHLEN];
-
-                    // Convert the path from a CFString to a C (NUL-terminated)
-                    result = CFStringGetCString(bsdPathAsCFString,
-                                                bsdPath,
-                                                sizeof(bsdPath),
-                                                kCFStringEncodingUTF8);
-
-                    CFRelease(bsdPathAsCFString);
-
-                    if (result && (strcmp(bsdPath, pathName) == 0))
-                    {
-                        deviceFound = true;
-                        //memset(bsdPath, 0, sizeof(bsdPath));
-                        device = service;
-                    }
-                    else
-                    {
-                       // Release the object which are no longer needed
-                       (void) IOObjectRelease(service);
-                    }
-                }
-            }
-            // Release the iterator.
-            IOObjectRelease(matchingServices);
-        }
-    }
-
+  if (!service) {
     return device;
+  }
+
+  status = IORegistryEntryCreateIterator(service,
+                                         kIOServicePlane,
+                                         (kIORegistryIterateParents | kIORegistryIterateRecursively),
+                                         &iterator);
+
+  if (status == kIOReturnSuccess)
+  {
+    io_service_t currentService;
+    while ((currentService = IOIteratorNext(iterator)))
+    {
+      io_name_t serviceName;
+      status = IORegistryEntryGetNameInPlane(currentService, kIOServicePlane, serviceName);
+      if (status == kIOReturnSuccess && (IOObjectConformsTo(currentService, kIOUSBDeviceClassName))) {
+        device = currentService;
+        break;
+      }
+    }
+  }
+  return device;
 }
 
 static void ExtractUsbInformation(stSerialDevice *serialDevice, IOUSBDeviceInterface  **deviceInterface)
@@ -583,14 +562,13 @@ static stDeviceListItem* GetSerialDevices()
 
                 uv_mutex_lock(&list_mutex);
 
-                io_registry_entry_t device = GetUsbDevice(bsdPath);
+                io_service_t device = GetUsbDevice(modemService);
 
                 if (device) {
-                    CFStringRef manufacturerAsCFString = (CFStringRef) IORegistryEntrySearchCFProperty(device,
-                                          kIOServicePlane,
+                    CFStringRef manufacturerAsCFString = (CFStringRef) IORegistryEntryCreateCFProperty(device,
                                           CFSTR(kUSBVendorString),
                                           kCFAllocatorDefault,
-                                          kIORegistryIterateRecursively);
+                                          0);
 
                     if (manufacturerAsCFString)
                     {


### PR DESCRIPTION
It appears as though the registry topology has changed in 10.11

In order to fix that, this code assumes nothing about the path, but instead works on the assumption that we can already find the registry entry as soon as the device is enumerated.  By increasing the bounds of the search we have a better chance of finding the appropriate registry entry.

Please test this on older OSX versions!

fixes #552