### PR TITLE
Fix Wtautological-pointer-compare warnings: Dereference pointers to check for emptiness, instead of comparing pointer to != NULL.

### DIFF
--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -692,19 +692,19 @@ void EIO_List(uv_work_t* req) {
         ListResultItem* resultItem = new ListResultItem();
         resultItem->comName = device.port;
 
-        if (device.locationId != NULL) {
+        if (*device.locationId) {
           resultItem->locationId = device.locationId;
         }
-        if (device.vendorId != NULL) {
+        if (*device.vendorId) {
           resultItem->vendorId = device.vendorId;
         }
-        if (device.productId != NULL) {
+        if (*device.productId) {
           resultItem->productId = device.productId;
         }
-        if (device.manufacturer != NULL) {
+        if (*device.manufacturer) {
           resultItem->manufacturer = device.manufacturer;
         }
-        if (device.serialNumber != NULL) {
+        if (*device.serialNumber) {
           resultItem->serialNumber = device.serialNumber;
         }
         data->results.push_back(resultItem);


### PR DESCRIPTION
Fixes:

```
> serialport@2.0.1 install /Users/rwaldron/clonez/node-serialport
> node-pre-gyp install --fallback-to-build

(node) child_process: options.customFds option is deprecated. Use options.stdio instead.
  CXX(target) Release/obj.target/serialport/src/serialport.o
  CXX(target) Release/obj.target/serialport/src/serialport_unix.o
../src/serialport_unix.cpp:695:20: warning: comparison of array 'device.locationId' not
      equal to a null pointer is always true [-Wtautological-pointer-compare]
        if (device.locationId != NULL) {
            ~~~~~~~^~~~~~~~~~    ~~~~
../src/serialport_unix.cpp:698:20: warning: comparison of array 'device.vendorId' not
      equal to a null pointer is always true [-Wtautological-pointer-compare]
        if (device.vendorId != NULL) {
            ~~~~~~~^~~~~~~~    ~~~~
../src/serialport_unix.cpp:701:20: warning: comparison of array 'device.productId' not
      equal to a null pointer is always true [-Wtautological-pointer-compare]
        if (device.productId != NULL) {
            ~~~~~~~^~~~~~~~~    ~~~~
../src/serialport_unix.cpp:704:20: warning: comparison of array 'device.manufacturer' not
      equal to a null pointer is always true [-Wtautological-pointer-compare]
        if (device.manufacturer != NULL) {
            ~~~~~~~^~~~~~~~~~~~    ~~~~
../src/serialport_unix.cpp:707:20: warning: comparison of array 'device.serialNumber' not
      equal to a null pointer is always true [-Wtautological-pointer-compare]
        if (device.serialNumber != NULL) {
            ~~~~~~~^~~~~~~~~~~~    ~~~~
5 warnings generated.
```


Note: This is blocking the next Johnny-Five release, so... <3 in advance :)