### PR TITLE
Avoid crash when as_json.DEVLINKS is missing

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -538,8 +538,10 @@ function SerialPortFactory(_spfOptions) {
         return result;
       }
       var as_json = udev_output_to_json(udev_output);
-      var pnpId = as_json.DEVLINKS.split(' ')[0];
-      pnpId = pnpId.substring(pnpId.lastIndexOf('/') + 1);
+      if(as_json.DEVLINKS) {
+        var pnpId = as_json.DEVLINKS.split(' ')[0];
+        pnpId = pnpId.substring(pnpId.lastIndexOf('/') + 1);
+      }
       var port = {
         comName: as_json.DEVNAME,
         manufacturer: as_json.ID_VENDOR,


### PR DESCRIPTION
On Linux, the `listUnix` grabs all the terminals (ttyS0, ttyS1, ...). Since those are missing a lot of information including `DEVLINKS`, `udev_parser` crashes. This checks the presence of `DEVLINKS` before manipulating it. Fixes #626 

Example of `udev_parser` output for a TTY on Linux:
```
{ comName: '/dev/ttyS8',
  manufacturer: undefined,
  serialNumber: undefined,
  pnpId: undefined,
  vendorId: '0xundefined',
  productId: '0xundefined' }
```