### PR TITLE
We get rid of the ambiguity:  /dev/serial/by-path or /dev/serial/by-id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serialport",
-  "version": "2.0.5.1",
+  "version": "2.0.5",
   "description": "Welcome your robotic javascript overlords. Better yet, program them!",
   "author": {
     "name": "Chris Williams",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serialport",
-  "version": "2.0.5",
+  "version": "2.0.5.1",
   "description": "Welcome your robotic javascript overlords. Better yet, program them!",
   "author": {
     "name": "Chris Williams",

--- a/serialport.js
+++ b/serialport.js
@@ -540,8 +540,12 @@ function SerialPortFactory(_spfOptions) {
       var as_json = udev_output_to_json(udev_output);
 
       var pnpId;
+      // queryPortsByPath is always false?
+      var rePnpId = (spfOptions.queryPortsByPath ? /\/dev\/serial\/by-path\/(\S*)/g : /\/dev\/serial\/by-id\/(\S*)/g);
+      var matches;
       if(as_json.DEVLINKS) {
-        pnpId = as_json.DEVLINKS.split(' ')[0];
+        matches = rePnpId.exec(as_json.DEVLINKS);
+        pnpId = matches && matches[1] || as_json.DEVLINKS.split(' ')[0];
         pnpId = pnpId.substring(pnpId.lastIndexOf('/') + 1);
       }
       var port = {

--- a/serialport.js
+++ b/serialport.js
@@ -599,8 +599,8 @@ function SerialPortFactory(_spfOptions) {
 
           udev_parser(stdout, callback);
         });
-      }, function(ports) {
-        callback(ports.filter(port=>!!port));
+      }, function(err, ports) {
+        callback(err, ports && ports.filter(port => !!port));
       });
     });
   }

--- a/serialport.js
+++ b/serialport.js
@@ -590,7 +590,7 @@ function SerialPortFactory(_spfOptions) {
         exec('/sbin/udevadm info --query=property -p $(/sbin/udevadm info -q path -n ' + fileName + ')', function (err, stdout) {
           if (err) {
             if (callback) {
-              callback(err);
+              callback();
             } else {
               factory.emit('error', err);
             }
@@ -599,7 +599,9 @@ function SerialPortFactory(_spfOptions) {
 
           udev_parser(stdout, callback);
         });
-      }, callback);
+      }, function(ports) {
+        callback(ports.filter(port=>!!port));
+      });
     });
   }
 


### PR DESCRIPTION
patch on Issue #634