### PR TITLE
Add Node.js 5.1 to Travis & AppVeyor builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,11 @@ env:
   - TRAVIS_NODE_VERSION="0.10"
   - TRAVIS_NODE_VERSION="0.12"
   - TRAVIS_NODE_VERSION="4"
+  - TRAVIS_NODE_VERSION="5"
   - TRAVIS_NODE_VERSION="0.10" ARCH="x86"
   - TRAVIS_NODE_VERSION="0.12" ARCH="x86"
   - TRAVIS_NODE_VERSION="4" ARCH="x86"
+  - TRAVIS_NODE_VERSION="5" ARCH="x86"
   global:
   - secure: nFQKlcfG1rV/kQm1EJtgQyRefZb6scdn/9epEaJgAyaqDRXHSZIFSuoOh4d/P5GC6V0yi6dA8I+XJsoRy29qG+JXWxN2enwjp16IbpUri9Z5H8uZPur1N6QPby9BX+PX5/4HU+KRgWtFDdfqqzbLmObXsxIUGtZtBbRY9otiUt8=
   exclude:
@@ -29,6 +31,8 @@ env:
     env: TRAVIS_NODE_VERSION="0.12" ARCH="x86"
   - os: osx
     env: TRAVIS_NODE_VERSION="4" ARCH="x86"
+  - os: osx
+    env: TRAVIS_NODE_VERSION="5" ARCH="x86"
 
 before_install:
 # reinstall latest nvm

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This assumes you have everything on your system necessary to compile ANY native 
 
 #### Mac OS X:
 
-Ensure that you have at a minimum the xCode Command Line Tools installed appropriate for your system configuration. If you recently upgraded the OS, it probably removed your installation of Command Line Tools, please verify before submitting a ticket. In order to compile it with Node.js 5.x+, you will need to use g++ v4.8 or higher.
+Ensure that you have at a minimum the xCode Command Line Tools installed appropriate for your system configuration. If you recently upgraded the OS, it probably removed your installation of Command Line Tools, please verify before submitting a ticket. To compile `node-serialport` with Node.js 4.x+, you will need to use g++ v4.8 or higher.
 
 #### Desktop (Debian/Ubuntu) Linux:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install serialport
 
 ### Installation Special Cases
 
-We are using [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) to compile and post binaries of the library for most common use cases (linux, mac, windows on standard processor platforms). If you are on a special case, node-serialport will work, but it will compile the binary when you install. 
+We are using [node-pre-gyp](https://github.com/mapbox/node-pre-gyp) to compile and post binaries of the library for most common use cases (linux, mac, windows on standard processor platforms). If you are on a special case, node-serialport will work, but it will compile the binary when you install.
 
 This assumes you have everything on your system necessary to compile ANY native module for Node.js. This may not be the case, though, so please ensure the following are true for your system before filing an issue about "Does not install". For all operatings systems, please ensure you have Python 2.x installed AND not 3.0, node-gyp (what we use to compile) requires Python 2.x.
 
@@ -44,11 +44,11 @@ This assumes you have everything on your system necessary to compile ANY native 
 
 #### Mac OS X:
 
-Ensure that you have at a minimum the xCode Command Line Tools installed appropriate for your system configuration. If you recently upgraded the OS, it probably removed your installation of Command Line Tools, please verify before submitting a ticket.
+Ensure that you have at a minimum the xCode Command Line Tools installed appropriate for your system configuration. If you recently upgraded the OS, it probably removed your installation of Command Line Tools, please verify before submitting a ticket. In order to compile it with Node.js 5.x+, you will need to use g++ v4.8 or higher.
 
 #### Desktop (Debian/Ubuntu) Linux:
 
-You know what you need for you system, basically your appropriate analog of build-essential. Keep rocking! Ubuntu renamed the `node` binary `nodejs` which can cause problems building `node-serialport`. The fix is simple, install the [nodejs-legacy package](https://packages.debian.org/sid/nodejs-legacy) that symlinks `/usr/bin/nodejs => /usr/bin/node` or install the more up to date nodejs package from [Chris Lea's PPA](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#ubuntu-mint-elementary-os).
+You know what you need for your system, basically your appropriate analog of build-essential. Keep rocking! Ubuntu renamed the `node` binary `nodejs` which can cause problems building `node-serialport`. The fix is simple, install the [nodejs-legacy package](https://packages.debian.org/sid/nodejs-legacy) that symlinks `/usr/bin/nodejs => /usr/bin/node` or install the more up to date nodejs package from [Chris Lea's PPA](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager#ubuntu-mint-elementary-os).
 
 
 ```
@@ -345,4 +345,3 @@ Called once a connection is closed. Closing a connection will also remove all ev
 
 &nbsp;
 &nbsp;
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ environment:
   - nodejs_version: "0.10"
   - nodejs_version: "0.12"
   - nodejs_version: "4.2"
+  - nodejs_version: "5.0"
 
 platform:
   - x86

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
   - nodejs_version: "0.10"
   - nodejs_version: "0.12"
   - nodejs_version: "4.2"
-  - nodejs_version: "5.0"
+  - nodejs_version: "5.1"
 
 platform:
   - x86

--- a/publish-binaries.md
+++ b/publish-binaries.md
@@ -3,13 +3,13 @@ How to publish the pre compiled binaries.
 
 ## Setup for Linux, Windows and OSX
 
-Every time a new tag for the latest release is pushed to github the continuous integration
+Every time a new tag for the latest release is pushed to Github, the continuous integration
 builds in Travis-CI and AppVeyor will generate the binaries for each platform and architecture.
 We use [node-pre-gyp-github](https://github.com/bchr02/node-pre-gyp-github) on top of node-pre-gyp
-to put binaries on Github instead of S3.
+to publish these binaries on Github, instead of S3.
 
-This can be checked in the .travis.yml file and appveyor.yml file. Within the files there are two
-methods for publishing new binaries for each version, one is if a `git tag` is detected; the other
+This can be checked in the .travis.yml file and appveyor.yml file. Within these files, there are two
+methods for publishing new binaries for each version: one is if a `git tag` is detected; the other
 can be triggered by passing the string `[publish binary]` in the commit message itself.
 
 We have an automated make task, we should always use this task to avoid forgetting any steps. The process for generating the binaries, publishing and releasing the npm module should be as follows:
@@ -17,31 +17,30 @@ We have an automated make task, we should always use this task to avoid forgetti
 1. Merge all changes and new features into master.
 2. Fill out changelog.md.
 3. Bump up npm version *AND* binary host version in `package.json`, commit and push.
-3. rum command: `make release`
+3. run command: `make release`
 
 This task will do the following for you:
 
 1. Generate new tags based on package.json version number
 2. Push tags to Github
 
-From here, travis and appveyor detect release tag commit and build for release. As the builds (presumably) succeed you should see binaries showing up on the github releases page. While you wait, why not copy the changelog updates into the release field? You probably want to wait (hours?) for appveyor success, check that all binaries exist, and then finally don't forget to run `npm publish`
+From here, Travis and AppVeyor detect release tag commit, and build for release. As the builds (presumably) succeed you should see binaries showing up on the Github releases page. While you wait, why not copy the changelog updates into the release field? You probably want to wait (hours?) for Appveyor success, check that all binaries exist, and then finally don't forget to run `npm publish`
 
 
 ## Config Travis, AppVeyor and Github to generate all of the binaries.
 
 Before we are able to run everything stated above some steps need to be taken.
 Specifically for being able to publish the pre compiled binaries to Github. The
-correct keys need to be setup in the travis and appveyor `.yml` files. This needs
-to be done by the admin of the repo, in the case of Travis, and the owner of the account,
-in the case of appveyor.
+correct keys need to be setup in the `travis.yml` and `appveyor.yml` files. For Travis, this needs
+to be done by the admin of the Github repo. For AppVeyor, this will need to be done by the owner of the AppVeyor account.
 
 ### Setting up secure keys in Travis.
 
-Setting up the keys in Travis is easy if you have ruby and ruby gems installed and working then install:
+Setting up the keys in Travis is easy if you have Ruby and Rubygems installed and working then run:
 
 `gem install travis`
 
-After the travis gem is installed run the following command for each of the required keys:
+After the Travis gem is installed run the following command for each of the required keys:
 
 `travis encrypt SOMEVAR=secretvalue`
 
@@ -50,8 +49,6 @@ be found here: http://docs.travis-ci.com/user/environment-variables/#Secure-Vari
 
 ### Setting up secure keys in AppVeyor
 
-It is even easier than Travis, you do not need to install anything, just go to your account and
-click in `encrypt tool`, there enter the values in the input field and click encrypt. Same as with
-Travis we then need to substitute the newly generated values for the old ones.
+It is even easier than Travis to configure AppVeyor. You do not need to install anything, just go to your account and click on `encrypt tool`. Enter the values in the input field and click "Encrypt". In the same way as we do for Travis, we then need to substitute the newly generated values for the old ones.
 
 Detailed instructions can be found here: http://www.appveyor.com/docs/build-configuration#secure-variables


### PR DESCRIPTION
This PR adds support for Node 5.1 to the Travis & AppVeyor continuous integration builds. It should allow for the precompiled binaries to be published as part of a release build on both OSX & Windows for the latest stable Node.js version.