### PR TITLE
Remove deprecated BuildCommDCB for windows 10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ This assumes you have everything on your system necessary to compile ANY native 
 
 #### Windows:
 
- * Windows 7 or Windows 8.1 are supported.
+ * Windows 7, Windows 8.1, and Windows 10 are supported.
+ * Might just download and install with no extra steps. If the downloaded binary fails you'll have to build it with the following steps.
  * Install [Visual Studio Express 2013 for Windows Desktop](http://www.microsoft.com/visualstudio/eng/2013-downloads#d-2013-express).
  * If you are hacking on an Arduino, be sure to install [the drivers](http://arduino.cc/en/Guide/windows#toc4).
  * Install [node.js](http://nodejs.org/) matching the bitness (32 or 64) of your operating system.

--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -80,12 +80,21 @@ void EIO_Open(uv_work_t* req) {
 
   DCB dcb = { 0 };
   dcb.DCBlength = sizeof(DCB);
-  if(data->hupcl == false)
+  if(data->hupcl == false) {
       dcb.fDtrControl = DTR_CONTROL_DISABLE; // disable DTR to avoid reset
-  if(!BuildCommDCB("9600,n,8,1", &dcb)) {
-    ErrorCodeToString("BuildCommDCB", GetLastError(), data->errorString);
-    return;
+  } else {
+    dcb.fDtrControl = DTR_CONTROL_ENABLE;
   }
+
+  dcb.BaudRate = CBR_9600;
+  dcb.Parity = NOPARITY;
+  dcb.ByteSize = 8;
+  dcb.StopBits = ONESTOPBIT;
+  dcb.fInX = FALSE;
+  dcb.fOutX = FALSE;
+  dcb.fOutxDsrFlow = FALSE;
+  dcb.fOutxCtsFlow = FALSE;
+  dcb.fRtsControl = RTS_CONTROL_ENABLE;
 
   dcb.fBinary = true;
   dcb.BaudRate = data->baudRate;


### PR DESCRIPTION
- This replaces the removed shortcut methods to build a serial port
object with the non deprecated long form.
- Unit and Smoke tested on windows 10.
- Replaces #550 as that source tree has disappeared.

cc @munyirik @mattpodwysocki

Tested on
 - [x] Windows 7
 - [x] Windows 8.1
 - [x] Windows 10
 - [ ] Windows 10 IoT Core
