### PR TITLE
fix race condition closing serial port

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -342,7 +342,7 @@ function SerialPortFactory(_spfOptions) {
         self.reading = false;
         if (err) {
           if (err.code && err.code === 'EAGAIN') {
-            if (self.fd >= 0) {
+            if (!self.closing && self.fd >= 0) {
               self.serialPoller.start();
             }
           } else if (err.code && (err.code === 'EBADF' || err.code === 'ENXIO' || (err.errno === -1 || err.code === 'UNKNOWN'))) { // handle edge case were mac/unix doesn't clearly know the error.


### PR DESCRIPTION
If SerialPort.close() is invoked while fs.read() is blocked the
post-read callback can re-enable the poller after the descriptor has
been closed.  Add a check to prevent this.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>