### PR TITLE
Updated Raspberry Pi docs to link to Raspi IO

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,29 +89,7 @@ npm install serialport
 
 #### Raspberry Pi Linux:
 
- * Starting with a a vanilla New Out of the Box Software (NOOBS) Raspbian image
- * Log into your Raspberry Pi through whatever means works best and ensure you are on a terminal prompt for the remaining steps. This could be local or through an SSH (or a serial connection if you like).
- * Issue the following commands to ensure you are up to date:
-
-```bash
-   sudo apt-get update
-   sudo apt-get upgrade -y
-```
-
- * Download and install node.js:
-
-```bash
-   wget https://node-arm.herokuapp.com/node_archive_armhf.deb
-   sudo dpkg -i node_archive_armhf.deb
-```
-
-More information can be found at [node-arm](http://node-arm.herokuapp.com/).
-
- * Install using npm, note this will take a while as it is actually compiling code and that ARM processor is getting a workout.
-
-```bash
-   npm install serialport
-```
+Follow the instructions for [setting up a Raspberry pi for use with Johnny-Five and Raspi IO](https://github.com/nebrius/raspi-io/wiki/Getting-a-Raspberry-Pi-ready-for-NodeBots). These projects use Node Serialport under the hood.
 
 ## Usage
 


### PR DESCRIPTION
Raspi IO (finally) has an in depth, up to date wiki document that details how to get a Raspberry Pi set up for use with NodeBots, and this switches to using that wiki for the RPi.