### PR TITLE
Bugfixes around JS handling of file descriptors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
       }
     },
     eslint: {
-      src: ['*.js', 'test/**/*.js', 'arduinoTest/**/*.js']
+      src: ['*.js', 'test/**/*.js', 'test_mocks/**/*.js', 'arduinoTest/**/*.js']
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
   "license": "MIT",
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",
+    "rebuild": "node-pre-gyp rebuild",
     "test": "grunt --verbose"
   }
 }

--- a/serialport.js
+++ b/serialport.js
@@ -328,7 +328,7 @@ function SerialPortFactory(_spfOptions) {
         self.reading = false;
         if (err) {
           if (err.code && err.code === 'EAGAIN') {
-            if (self.isOpen()) {
+            if (!self.closing && self.isOpen()) {
               self.serialPoller.start();
             }
           // handle edge case were mac/unix doesn't clearly know the error.

--- a/test_mocks/linux-hardware.js
+++ b/test_mocks/linux-hardware.js
@@ -1,12 +1,12 @@
 // This takes a serial-port factory and mocks the shit out of it in complete isolation per require of this file
 
-"use strict";
+'use strict';
 
 var mockSerialportPoller = function (hardware) {
-  var Poller = function (path, cb) {
-    this.port = hardware.ports[path];
+  var Poller = function (fd, cb) {
+    this.port = hardware.fds[fd];
     if (!this.port) {
-      throw new Error(path + " does not exist - please call hardware.createPort(path) first");
+      throw new Error(fd + ' does not exist - please call hardware.createPort(path) first');
     }
     this.port.poller = this;
     this.polling = null;
@@ -25,22 +25,33 @@ var mockSerialportPoller = function (hardware) {
 };
 
 var Hardware = function () {
+  this.nextFd = 0;
+  this.fds = {};
   this.ports = {};
   this.mockBinding = {
     list: this.list.bind(this),
     open: this.open.bind(this),
+    update: this.update.bind(this),
     write: this.write.bind(this),
     close: this.close.bind(this),
     flush: this.flush.bind(this),
+    set: this.set.bind(this),
+    drain: this.drain.bind(this),
     SerialportPoller: mockSerialportPoller(this)
   };
 };
 
 Hardware.prototype.reset = function () {
   this.ports = {};
+  this.fds = {};
+  this.nextFd = 0;
 };
 
 Hardware.prototype.createPort = function (path) {
+  if (this.ports[path]) {
+    delete this.fds[this.ports[path].fd];
+  }
+  var fd = this.nextFd++;
   this.ports[path] = {
     data: new Buffer(0),
     lastWrite: null,
@@ -54,14 +65,16 @@ Hardware.prototype.createPort = function (path) {
       locationId: '',
       vendorId: '',
       productId: ''
-    }
+    },
+    fd: fd
   };
+  this.fds[fd] = this.ports[path];
 };
 
 Hardware.prototype.emitData = function (path, data) {
   var port = this.ports[path];
-  if(!port) {
-    throw new Error(path + " does not exist - please call hardware.createPort(path) first");
+  if (!port) {
+    throw new Error(path + ' does not exist - please call hardware.createPort(path) first');
   }
   port.data = Buffer.concat([port.data, data]);
   port.poller && port.poller.detectRead();
@@ -70,9 +83,9 @@ Hardware.prototype.emitData = function (path, data) {
 Hardware.prototype.disconnect = function (path) {
   var port = this.ports[path];
   if (!port) {
-    throw new Error(path + " does not exist - please call hardware.createPort(path) first");
+    throw new Error(path + ' does not exist - please call hardware.createPort(path) first');
   }
-  port.openOpt.disconnectedCallback();
+  port.openOpt.disconnectedCallback && port.openOpt.disconnectedCallback();
 };
 
 Hardware.prototype.list = function (cb) {
@@ -86,49 +99,73 @@ Hardware.prototype.list = function (cb) {
 Hardware.prototype.open = function (path, opt, cb) {
   var port = this.ports[path];
   if (!port) {
-    return cb(new Error(path + " does not exist - please call hardware.createPort(path) first"));
+    return cb(new Error(path + ' does not exist - please call hardware.createPort(path) first'));
   }
   port.open = true;
   port.openOpt = opt;
-  cb && cb(null, path); // using path as the fd for convience
+  cb && cb(null, port.fd);
 };
 
-Hardware.prototype.write = function (path, buffer, cb) {
-  var port = this.ports[path];
+Hardware.prototype.update = function(fd, opt, cb) {
+  var port = this.fds[fd];
   if (!port) {
-    return cb(new Error(path + " does not exist - please call hardware.createPort(path) first"));
+    return cb(new Error(fd + ' does not exist - please call hardware.createPort(path) first'));
   }
-  port.lastWrite = new Buffer(buffer); //copy
+  cb && cb();
+};
+
+Hardware.prototype.write = function (fd, buffer, cb) {
+  var port = this.fds[fd];
+  if (!port) {
+    return cb(new Error(fd + ' does not exist - please call hardware.createPort(path) first'));
+  }
+  port.lastWrite = new Buffer(buffer); // copy
   cb && cb(null, buffer.length);
 };
 
-Hardware.prototype.close = function (path, cb) {
-  var port = this.ports[path];
+Hardware.prototype.close = function (fd, cb) {
+  var port = this.fds[fd];
   if (!port) {
-    return cb(new Error(path + " does not exist - please call hardware.createPort(path) first"));
+    return cb(new Error(fd + ' does not exist - please call hardware.createPort(path) first'));
   }
   port.open = false;
   cb && cb(null);
 };
 
-Hardware.prototype.flush = function (path, cb) {
-  var port = this.ports[path];
+Hardware.prototype.flush = function (fd, cb) {
+  var port = this.fds[fd];
   if (!port) {
-    return cb(new Error(path + " does not exist - please call hardware.createPort(path) first"));
+    return cb(new Error(fd + ' does not exist - please call hardware.createPort(path) first'));
   }
   cb && cb(null, undefined);
 };
 
-Hardware.prototype.fakeRead = function (path, buffer, offset, length, position, cb) {
-  var port = this.ports[path];
+Hardware.prototype.set = function (fd, options, cb) {
+  var port = this.fds[fd];
   if (!port) {
-    return cb(new Error(path + " does not exist - please call hardware.createPort(path) first"));
+    return cb(new Error(fd + ' does not exist - please call hardware.createPort(path) first'));
+  }
+  cb && cb(null, undefined);
+};
+
+Hardware.prototype.drain = function (fd, cb) {
+  var port = this.fds[fd];
+  if (!port) {
+    return cb(new Error(fd + ' does not exist - please call hardware.createPort(path) first'));
+  }
+  cb && cb(null, undefined);
+};
+
+Hardware.prototype.fakeRead = function (fd, buffer, offset, length, position, cb) {
+  var port = this.fds[fd];
+  if (!port) {
+    return cb(new Error(fd + ' does not exist - please call hardware.createPort(path) first'));
   }
   if (port.data.length === 0) {
     return cb(null, 0, buffer);
   }
   if ((offset + length) > buffer.length) {
-    throw new Error("Length extends beyond buffer");
+    throw new Error('Length extends beyond buffer');
   }
 
   // node v0.8 doesn't like a slice that is bigger then available data


### PR DESCRIPTION
This patch combines #586 and #686

A big thanks to @ecksun and @pabigot for discovering and helping make these changes. 

I started to cleanup our logic around checking if the port was open.

Disconnections are weird, but no weirder than before this patch. @ecksun's notes below.

 - A closed serialport now uses fd = null
 - Emulate a proper fd in mock hardware
 - Instead of using the device path as the file descriptor, use a generated
integer as the fd.

The open(2) manpage states that the file descriptor will be a small nonnegative integer. Checking if the fd is falsey leads to the incorrect classification of the fd 0 as invalid. That is not the case, open(2) specifies the fd as "a small, nonnegative integer".

This also adds tests for all the cases where the fd was previously incorrectly considered invalid, which required adding three more methods to the mock-hardware (update, set and drain).

This solves issue #472