### PR TITLE
add pieces missed in pr #703

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -345,7 +345,7 @@ function SerialPortFactory(_spfOptions) {
           self.pool.used -= bytesRequested - bytesRead;
 
           if (bytesRead === 0) {
-            if (self.fd >= 0) {
+            if (self.isOpen()) {
               self.serialPoller.start();
             }
           } else {

--- a/serialport.js
+++ b/serialport.js
@@ -211,7 +211,6 @@ function SerialPortFactory(_spfOptions) {
     this.readable = true;
     this.reading = false;
     factory.SerialPortBinding.open(this.path, this.options, function (err, fd) {
-      self.fd = fd;
       if (err) {
         if (callback) {
           callback(err);
@@ -220,6 +219,7 @@ function SerialPortFactory(_spfOptions) {
         }
         return;
       }
+      self.fd = fd;
       if (process.platform !== 'win32') {
         self.paused = false;
         self.serialPoller = new factory.SerialPortBinding.SerialportPoller(self.fd, function (err) {


### PR DESCRIPTION
@jacobrosenthal 

Mentioned in review comments but weren't incorporated before #703 was merged.  The first removes an inconsistency; the other would be a real problem (`isOpen()` would succeed even though the open failed).