### PR TITLE
Upgrade to NAN v2.2.1 for Node.js v6.0.0-nightly compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "async": "0.9.0",
     "bindings": "1.2.1",
     "debug": "^2.1.1",
-    "nan": "~2.0.0",
+    "nan": "~2.2.1",
     "node-pre-gyp": "0.6.x",
     "node-pre-gyp-github": "^1.1.0",
     "optimist": "~0.6.1",


### PR DESCRIPTION
node-serialport currently depends on NAN ~2.0.0 which is too old for Node.js v6.0.0-nightly20160307061ebb39c9. Installing node-serialport with Node.js v6.0.0-nightly20160307061ebb39c9 results in compile errors (see below.) Upgrading to NAN v2.2.1 solves the problem.

Note that this PR wasn't tested a lot.

```
pi@raspberrypi:~/serialport $ npm install serialport@2.0.7-beta2
(node:7165) fs: re-evaluating native module sources is not supported. If you are using the graceful-fs module, please update it to a more recent version.

> serialport@2.0.7-beta2 install /home/pi/serialport/node_modules/serialport
> node-pre-gyp install --fallback-to-build

make: Entering directory '/home/pi/serialport/node_modules/serialport/build'
  CXX(target) Release/obj.target/serialport/src/serialport.o
In file included from ../src/serialport.h:5:0,
                 from ../src/serialport.cpp:3:
../../nan/nan.h:590:20: error: variable or field ‘AddGCEpilogueCallback’ declared void
       v8::Isolate::GCEpilogueCallback callback
                    ^
../../nan/nan.h:590:7: error: ‘GCEpilogueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCEpilogueCallback callback
       ^
../../nan/nan.h:591:18: error: expected primary-expression before ‘gc_type_filter’
     , v8::GCType gc_type_filter = v8::kGCTypeAll) {
                  ^
../../nan/nan.h:596:20: error: variable or field ‘RemoveGCEpilogueCallback’ declared void
       v8::Isolate::GCEpilogueCallback callback) {
                    ^
../../nan/nan.h:596:7: error: ‘GCEpilogueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCEpilogueCallback callback) {
       ^
../../nan/nan.h:601:20: error: variable or field ‘AddGCPrologueCallback’ declared void
       v8::Isolate::GCPrologueCallback callback
                    ^
../../nan/nan.h:601:7: error: ‘GCPrologueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCPrologueCallback callback
       ^
../../nan/nan.h:602:18: error: expected primary-expression before ‘gc_type_filter’
     , v8::GCType gc_type_filter = v8::kGCTypeAll) {
                  ^
../../nan/nan.h:607:20: error: variable or field ‘RemoveGCPrologueCallback’ declared void
       v8::Isolate::GCPrologueCallback callback) {
                    ^
../../nan/nan.h:607:7: error: ‘GCPrologueCallback’ is not a member of ‘v8::Isolate’
       v8::Isolate::GCPrologueCallback callback) {
       ^
serialport.target.mk:90: recipe for target 'Release/obj.target/serialport/src/serialport.o' failed
make: *** [Release/obj.target/serialport/src/serialport.o] Error 1
make: Leaving directory '/home/pi/serialport/node_modules/serialport/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/pi/opt/node-v6.0.0-nightly20160307061ebb39c9-linux-armv7l/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:101:13)
gyp ERR! stack     at ChildProcess.emit (events.js:186:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:204:12)
gyp ERR! System Linux 4.1.18-v7+
gyp ERR! command "/home/pi/opt/node-v6.0.0-nightly20160307061ebb39c9-linux-armv7l/bin/node" "/home/pi/opt/node-v6.0.0-nightly20160307061ebb39c9-linux-armv7l/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--module=/home/pi/serialport/node_modules/serialport/build/Release/node-v47-linux-arm/serialport.node" "--module_name=serialport" "--module_path=/home/pi/serialport/node_modules/serialport/build/Release/node-v47-linux-arm"
gyp ERR! cwd /home/pi/serialport/node_modules/serialport
gyp ERR! node -v v6.0.0-nightly20160307061ebb39c9
gyp ERR! node-gyp -v v3.2.1
gyp ERR! not ok 
node-pre-gyp ERR! build error 
node-pre-gyp ERR! stack Error: Failed to execute '/home/pi/opt/node-v6.0.0-nightly20160307061ebb39c9-linux-armv7l/bin/node /home/pi/opt/node-v6.0.0-nightly20160307061ebb39c9-linux-armv7l/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/home/pi/serialport/node_modules/serialport/build/Release/node-v47-linux-arm/serialport.node --module_name=serialport --module_path=/home/pi/serialport/node_modules/serialport/build/Release/node-v47-linux-arm' (1)
node-pre-gyp ERR! stack     at ChildProcess.<anonymous> (/home/pi/serialport/node_modules/serialport/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
node-pre-gyp ERR! stack     at emitTwo (events.js:101:13)
node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:186:7)
node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:850:16)
node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:215:5)
node-pre-gyp ERR! System Linux 4.1.18-v7+
node-pre-gyp ERR! command "/home/pi/opt/node-v6.0.0-nightly20160307061ebb39c9-linux-armv7l/bin/node" "/home/pi/serialport/node_modules/serialport/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
node-pre-gyp ERR! cwd /home/pi/serialport/node_modules/serialport
node-pre-gyp ERR! node -v v6.0.0-nightly20160307061ebb39c9
node-pre-gyp ERR! node-pre-gyp -v v0.6.18
node-pre-gyp ERR! not ok 
Failed to execute '/home/pi/opt/node-v6.0.0-nightly20160307061ebb39c9-linux-armv7l/bin/node /home/pi/opt/node-v6.0.0-nightly20160307061ebb39c9-linux-armv7l/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/home/pi/serialport/node_modules/serialport/build/Release/node-v47-linux-arm/serialport.node --module_name=serialport --module_path=/home/pi/serialport/node_modules/serialport/build/Release/node-v47-linux-arm' (1)
npm WARN enoent ENOENT: no such file or directory, open '/home/pi/serialport/package.json'
npm WARN serialport No description
npm WARN serialport No repository field.
npm WARN serialport No README data
npm WARN serialport No license field.
npm WARN You are using a pre-release version of node and things may not work as expected
npm ERR! Linux 4.1.18-v7+
npm ERR! argv "/home/pi/opt/node-v6.0.0-nightly20160307061ebb39c9-linux-armv7l/bin/node" "/home/pi/opt/node-v6.0.0-nightly20160307061ebb39c9-linux-armv7l/bin/npm" "install" "serialport@2.0.7-beta2"
npm ERR! node v6.0.0-nightly20160307061ebb39c9
npm ERR! npm  v3.6.0
npm ERR! code ELIFECYCLE

npm ERR! serialport@2.0.7-beta2 install: `node-pre-gyp install --fallback-to-build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the serialport@2.0.7-beta2 install script 'node-pre-gyp install --fallback-to-build'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the serialport package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node-pre-gyp install --fallback-to-build
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs serialport
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls serialport
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/pi/serialport/npm-debug.log
pi@raspberrypi:~/serialport $ 
```

Perhaps I'll manage a rebase the next time unlike with #707 