### PR TITLE
Closing a port is better tested & correctly reports isOpen in it’s event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ before_install:
 - $CXX --version
 # get commit message
 - COMMIT_MESSAGE=$(git show -s --format=%B $TRAVIS_COMMIT | tr -d '\n')
+# Set a test serialport for integration testing when we run our tests if we have one
+- if [[ $TRAVIS_OS_NAME == "osx" ]]; then export TEST_PORT='/dev/cu.serial1'; fi
 # figure out if we should publish
 - PUBLISH_BINARY=false
 # if we are building a tag then publish

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Closes an open connection.
 
 **_callback (optional)_**
 
-Called once a connection is closed. Closing a connection will also remove all event listeners. The callback should be a function that looks like: `function (error) { ... }`
+Called once a connection is closed. Closing a connection will also remove all event listeners. The callback should be a function that looks like: `function (error) { ... }` If called without an callback and there is an error, an error event will be emitted.
 
 ## Events
 
@@ -355,7 +355,7 @@ Callback is called with no arguments when the port is opened and ready for writi
 Callback is called with data depending on your chosen parser. The default `raw` parser will have a `Buffer` object with a varying amount of data in it. The `readLine` parser will provide a string of your line. See the [parsers](#parsers) section for more information
 
 ### .on('close', callback)
-Callback is called with no arguments when the port is closed.
+Callback is called with no arguments when the port is closed. In the event of an error, an error event will be triggered
 
 ### .on('error', callback)
 Callback is called with an error object whenever there is an error.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,9 +23,9 @@ platform:
   - x64
 
 install:
-  - cmd: ECHO %nodejs_version%
-  - cmd: ECHO %platform%
-  - cmd: ECHO %APPVEYOR_REPO_COMMIT_MESSAGE%
+  - cmd: ECHO "%nodejs_version%"
+  - cmd: ECHO "%platform%"
+  - cmd: ECHO "%APPVEYOR_REPO_COMMIT_MESSAGE%"
 
   - cmd: SET PATH=%cd%\node_modules\.bin\;%PATH%
   - ps:  Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:platform
@@ -45,6 +45,8 @@ install:
   # Or look for commit message containing `[publish binary]`
   - cmd: IF not x%COMMIT_MSG:[publish binary]=%==x%COMMIT_MSG% SET PUBLISH_BINARY=true
   - cmd: ECHO %PUBLISH_BINARY%
+  # Set a serialport for us to play with
+  - cmd: SET TEST_PORT=COM1
 
 build_script:
   - cmd: npm install --build-from-source --msvs_version=2013

--- a/serialport.js
+++ b/serialport.js
@@ -448,6 +448,7 @@ function SerialPortFactory(_spfOptions) {
     var fd = self.fd;
 
     if (self.closing) {
+      // TODO this should be an error
       return;
     }
     if (!this.isOpen()) {
@@ -480,21 +481,18 @@ function SerialPortFactory(_spfOptions) {
           return;
         }
 
-        self.emit('close');
-        self.removeAllListeners();
         self.closing = false;
         self.fd = null;
-
-        if (callback) {
-          callback();
-        }
+        self.emit('close');
+        if (callback) { callback() }
+        self.removeAllListeners();
       });
-    } catch (ex) {
+    } catch (err) {
       self.closing = false;
       if (callback) {
-        callback(ex);
+        callback(err);
       } else {
-        self.emit('error', ex);
+        self.emit('error', err);
       }
     }
   };

--- a/test/mocks/darwin-hardware.js
+++ b/test/mocks/darwin-hardware.js
@@ -128,6 +128,9 @@ Hardware.prototype.close = function (fd, cb) {
   if (!port) {
     return cb(new Error(fd + ' does not exist - please call hardware.createPort(path) first'));
   }
+  if (!port.open) {
+    return cb(new Error(fd + ' fd is already closed'));
+  }
   port.open = false;
   cb && cb(null);
 };

--- a/test/serialport-integration.js
+++ b/test/serialport-integration.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var chai = require('chai');
+var assert = require('chai').assert;
 var serialPort = require('../serialport');
 var SerialPort = serialPort.SerialPort;
 
@@ -8,12 +8,33 @@ describe('SerialPort', function () {
   describe('Initialization', function () {
     it('Throws an error in callback when trying to open an invalid port', function (done) {
       this.port = new SerialPort('/dev/nullbad', function (err) {
-        chai.assert.isDefined(err);
+        assert.isDefined(err);
         done();
       });
     });
   });
   it('.list', function(done) {
     serialPort.list(done);
+  });
+
+  describe('Working with virtual ports', function() {
+    var testPort = process.env.TEST_PORT;
+
+    if (!testPort) {
+      it('Cannot be tested as we have no test ports');
+      return;
+    }
+
+    it('can open and close ports', function(done) {
+      var port = new SerialPort(testPort);
+      port.on('open', function() {
+        assert.isTrue(port.isOpen());
+        port.close();
+      });
+      port.on('close', function() {
+        assert.isFalse(port.isOpen());
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
 - Ports correctly respond to `isOpen` during a close event
 - cleanup some assertions
 - if a CI has a port to test with, open and close it, currently osx and windows only

Bonus
 - Appveyor seems to think if you have a `&` in your commit message you’re trying to run a command