### PR TITLE
Dependency cleanup (quick pass)

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -6,18 +6,19 @@
 // node-pre-gyp, if something fails or package not available fallback
 // to regular build from source.
 
+// 3rd Party Dependencies
 var debug = require('debug')('serialport');
-var binary = require('node-pre-gyp');
-var path = require('path');
-var PACKAGE_JSON = path.join(__dirname, 'package.json');
-var binding_path = binary.find(path.resolve(PACKAGE_JSON));
-var SerialPortBinding = require(binding_path);
+
+// Internal Dependencies
+var SerialPortBinding = require('bindings')('serialport.node');
 var parsers = require('./lib/parsers');
 var listUnix = require('./lib/list-unix');
+
+// Built-ins Dependencies
 var EventEmitter = require('events').EventEmitter;
-var util = require('util');
 var fs = require('fs');
 var stream = require('stream');
+var util = require('util');
 
 function SerialPortFactory() {
   var factory = this;

--- a/test/mocks/darwin-hardware.js
+++ b/test/mocks/darwin-hardware.js
@@ -196,14 +196,8 @@ var serialPort = SandboxedModule.require('../../serialport', {
     fs: {
       read: hardware.fakeRead.bind(hardware)
     },
-    'node-pre-gyp': {
-      find: function() {
-        // this one is silly - we don't want it to find the binary
-        // so we say hey! it's this already mocked require!
-        // if it found the binary it would be loaded in a sandbox
-        // and wouldn't be able to be loaded in a regular context
-        return 'mock-binding';
-      }
+    'bindings': function() {
+      return hardware.mockBinding;
     },
     'mock-binding': hardware.mockBinding
   },


### PR DESCRIPTION
- Eliminates use of node-pre-gyp as an actual module dependency (just a package dependency, this might even be just a devDep now?)
- Reduces 5 blocking fs operations to 1

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>