### PR TITLE
Test & Fix a race condition when closing a port & trying to do anything

### DIFF
--- a/serialport.js
+++ b/serialport.js
@@ -238,12 +238,8 @@ SerialPort.prototype.open = function (callback) {
   var self = this;
   SerialPortBinding.open(this.path, this.options, function (err, fd) {
     if (err) {
-      if (callback) {
-        callback(err);
-      } else {
-        self.emit('error', err);
-      }
-      return;
+      debug('SerialPortBinding.open had an error', err);
+      return self._error(err, callback);
     }
     self.fd = fd;
     self.paused = false;
@@ -292,7 +288,7 @@ SerialPort.prototype.update = function (options, callback) {
 };
 
 SerialPort.prototype.isOpen = function() {
-  return this.fd !== null;
+  return this.fd !== null && !this.closing;
 };
 
 SerialPort.prototype.write = function (buffer, callback) {


### PR DESCRIPTION
 - isOpen() now pays attention to if we're in the middle of closing

Our faux state machine for opening and closing consists for 4 states
 - closed
 - opening
 - open
 - closing

Currently we only really care about if we're in open or not because that's when all our operations can happen. `#open` and `#close` care if they're opening or closing.