### PR TITLE
Define, document, and test flow control and setting port flags

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
     "no-caller": 2,
     "max-depth": 2,
     "complexity": [2, 32],
-    "max-statements": [2, 60],
+    "max-statements": [2, 41],
     "no-else-return": 2, // maybe
     "wrap-iife": [2, "inside"],
     "new-cap": 2,

--- a/README.md
+++ b/README.md
@@ -269,23 +269,18 @@ Port configuration options.
 * `dataBits` Data Bits, defaults to 8. Must be one of: 8, 7, 6, or 5.
 * `stopBits` Stop Bits, defaults to 1. Must be one of: 1 or 2.
 * `parity` Parity, defaults to 'none'. Must be one of: 'none', 'even', 'mark', 'odd', 'space'
-* `rtscts`
-* `xon`
-* `xoff`
-* `xany`
-* `flowControl` One of the following `XON`, `XOFF`, `XANY`, `RTSCTS`
-* `bufferSize` Size of read buffer, defaults to 255. Must be an integer value.
+* `rtscts` defaults to false
+* `xon` defaults to false
+* `xoff` defaults to false
+* `xany` defaults to false
+* `flowControl` `true` for `rtscts` or an array with one or more of the following strings to enable them `xon`, `xoff`, `xany`, `rtscts`. Overwrites any individual settings.
+* `bufferSize` Size of read buffer, defaults to 65536. Must be an integer value.
 * `parser` The parser engine to use with read data, defaults to rawPacket strategy which just emits the raw buffer as a "data" event. Can be any function that accepts EventEmitter as first parameter and the raw buffer as the second parameter.
-* `encoding`
-* `dataCallback`
-* `disconnectedCallback`
 * `platformOptions` - sets platform specific options, see below.
-
-**Note:** We have added support for either all lowercase OR camelcase of the options (thanks @jagautier), use whichever style you prefer.
 
 #### Unix Platform Options
 
-An object with the following properties:
+These properties are ignored for windows. An object with the following properties:
 
 * `vmin` (default: 1) - see [`man termios`](http://linux.die.net/man/3/termios)
 * `vtime` (default: 0) - see [`man termios`](http://linux.die.net/man/3/termios)
@@ -373,6 +368,26 @@ Closes an open connection.
 Called once a connection is closed. The callback should be a function that looks like: `function (error) { ... }` If called without an callback and there is an error, an error event will be emitted.
 
 **Note:** Currently closing a connection will also remove all event listeners.
+
+### .set (options, callback)
+
+Sets flags on an open port. Uses [`SetCommMask`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa363257(v=vs.85).aspx) for windows and [`ioctl`](http://linux.die.net/man/4/tty_ioctl) for mac and linux.
+
+**_options (optional)_**
+
+All options are operating system default when the port is opened. Every flag is set on each call to the provided or default values. If options isn't provided default options will be used.
+
+ * `brk` optional boolean, defaults to false
+ * `cts` optional boolean, defaults to false
+ * `dsr` optional boolean, defaults to false
+ * `dtr` optional boolean, defaults to true
+ * `rts` optional boolean, defaults to true
+
+**_callback (optional)_**
+
+`callback: function(err, results)`
+
+Called once the port's flags have been set. `results` are the return of the underlying system command. If `.set` is called without an callback and there is an error, an error event will be emitted.
 
 ## Events
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "nan": "~2.2.1",
     "node-pre-gyp": "0.6.x",
     "node-pre-gyp-github": "^1.1.0",
+    "object.assign": "^4.0.3",
     "optimist": "~0.6.1",
     "sf": "0.1.7"
   },
@@ -60,6 +61,7 @@
   ],
   "devDependencies": {
     "chai": "*",
+    "chai-subset": "^1.2.2",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",

--- a/test/serialport-basic.js
+++ b/test/serialport-basic.js
@@ -2,6 +2,7 @@
 
 var sinon = require('sinon');
 var chai = require('chai');
+chai.use(require('chai-subset'));
 var assert = chai.assert;
 var expect = chai.expect;
 
@@ -43,11 +44,11 @@ describe('SerialPort', function () {
         assert.instanceOf(err, Error);
         done();
       });
-      this.port = new SerialPort('/dev/johnJacobJingleheimerSchmidt');
+      this.port = new SerialPort('/bad/port');
     });
 
-    it('emits an error on the serial port when explicit error handler present', function (done) {
-      var port = new SerialPort('/dev/johnJacobJingleheimerSchmidt');
+    it('emits an error when an invalid port is provided', function (done) {
+      var port = new SerialPort('/bad/port');
       port.once('error', function(err) {
         assert.instanceOf(err, Error);
         done();
@@ -55,35 +56,67 @@ describe('SerialPort', function () {
     });
 
     it('errors with invalid databits', function (done) {
-      var errorCallback = function (err) {
+      this.port = new SerialPort('/dev/exists', { databits: 19 }, false, function (err) {
         assert.instanceOf(err, Error);
         done();
-      };
-      this.port = new SerialPort('/dev/exists', { databits: 19 }, false, errorCallback);
+      });
     });
 
     it('errors with invalid stopbits', function (done) {
-      var errorCallback = function (err) {
+      this.port = new SerialPort('/dev/exists', { stopbits: 19 }, function (err) {
         assert.instanceOf(err, Error);
         done();
-      };
-      this.port = new SerialPort('/dev/exists', { stopbits: 19 }, false, errorCallback);
+      });
     });
 
     it('errors with invalid parity', function (done) {
-      var errorCallback = function (err) {
+      this.port = new SerialPort('/dev/exists', { parity: 'pumpkins' }, false, function (err) {
         assert.instanceOf(err, Error);
         done();
-      };
-      this.port = new SerialPort('/dev/exists', { parity: 'pumpkins' }, false, errorCallback);
+      });
     });
 
-    it('errors with invalid flow control', function (done) {
-      var errorCallback = function (err) {
-        assert.instanceOf(err, Error);
+    describe('flowControl', function() {
+      it('errors with invalid flow control', function (done) {
+        var opts = { flowcontrol: ['pumpkins'] };
+        this.port = new SerialPort('/dev/exists', opts, false, function (err) {
+          assert.instanceOf(err, Error);
+          done();
+        });
+      });
+
+      it('sets valid flow control', function (done) {
+        var port = new SerialPort('/dev/exists', { flowcontrol: ['xon', 'XOFF', 'xany', 'RTSCTS'] }, false);
+        assert.isTrue(port.options.xon);
+        assert.isTrue(port.options.xoff);
+        assert.isTrue(port.options.xany);
+        assert.isTrue(port.options.rtscts);
         done();
-      };
-      this.port = new SerialPort('/dev/exists', { flowcontrol: ['pumpkins'] }, false, errorCallback);
+      });
+
+      it('sets rtscts to true if flow control is true', function (done) {
+        var port = new SerialPort('/dev/exists', { flowcontrol: true }, false);
+        assert.isFalse(port.options.xon);
+        assert.isFalse(port.options.xoff);
+        assert.isFalse(port.options.xany);
+        assert.isTrue(port.options.rtscts);
+        done();
+      });
+
+      it('sets valid flow control individually', function (done) {
+        var options = {
+          xon: true,
+          xoff: true,
+          xany: true,
+          rtscts: true
+        };
+        var port = new SerialPort('/dev/exists', options, false);
+        assert.isTrue(port.options.xon);
+        assert.isTrue(port.options.xoff);
+        assert.isTrue(port.options.xany);
+        assert.isTrue(port.options.rtscts);
+        done();
+      });
     });
 
     it('allows optional options', function (done) {
@@ -103,6 +136,29 @@ describe('SerialPort', function () {
           expect(openSpy.calledWith('/dev/exists'));
           done();
         });
+      });
+
+      it('passes default options to the bindings', function (done) {
+        var defaultOptions = {
+          baudRate: 9600,
+          parity: 'none',
+          xon: false,
+          xoff: false,
+          xany: false,
+          rtscts: false,
+          hupcl: true,
+          dataBits: 8,
+          stopBits: 1,
+          bufferSize: 65536
+        };
+        sandbox.stub(bindings, 'open', function (path, opt, cb) {
+          assert.equal(path, '/dev/exists');
+          assert.containSubset(opt, defaultOptions);
+          assert.isFunction(cb);
+          done();
+        });
+        var port = new SerialPort('/dev/exists', {}, false);
+        port.open();
       });
 
       it('calls back an error when opening an invalid port', function (done) {
@@ -273,6 +329,78 @@ describe('SerialPort', function () {
       });
     });
 
+    describe('#set', function() {
+      it('errors when serialport not open', function (done) {
+        var cb = function () {};
+        var port = new SerialPort('/dev/exists', {}, false, cb);
+        port.set({}, function(err) {
+          assert.instanceOf(err, Error);
+          done();
+        });
+      });
+
+      it('sets the flags on the ports bindings', function(done) {
+        var settings = {
+          brk: true,
+          cts: true,
+          dtr: true,
+          dts: true,
+          rts: true
+        };
+
+        sandbox.stub(bindings, 'set', function(fd, options) {
+          assert.deepEqual(options, settings);
+          done();
+        });
+
+        var port = new SerialPort('/dev/exists', function() {
+          port.set(settings);
+        });
+      });
+
+      it('sets missing options to default values', function(done) {
+        var settings = {
+          cts: true,
+          dts: true,
+          rts: false
+        };
+
+        var filledWithMissing = {
+          brk: false,
+          cts: true,
+          dtr: true,
+          dts: true,
+          rts: false
+        };
+        sandbox.stub(bindings, 'set', function(fd, options) {
+          assert.deepEqual(options, filledWithMissing);
+          done();
+        });
+
+        var port = new SerialPort('/dev/exists', function() {
+          port.set(settings);
+        });
+      });
+
+      it('resets all flags if none are provided', function (done) {
+        var defaults = {
+          brk: false,
+          cts: false,
+          dtr: true,
+          dts: false,
+          rts: true
+        };
+        sandbox.stub(bindings, 'set', function(fd, options) {
+          assert.deepEqual(options, defaults);
+          done();
+        });
+
+        var port = new SerialPort('/dev/exists', function() {
+          port.set();
+        });
+      });
+    });
+
     it('write errors when serialport not open', function (done) {
       var cb = function () {};
       var port = new SerialPort('/dev/exists', {}, false, cb);
@@ -286,15 +414,6 @@ describe('SerialPort', function () {
       var cb = function () {};
       var port = new SerialPort('/dev/exists', {}, false, cb);
       port.flush(function(err) {
-        assert.instanceOf(err, Error);
-        done();
-      });
-    });
-
-    it('set errors when serialport not open', function (done) {
-      var cb = function () {};
-      var port = new SerialPort('/dev/exists', {}, false, cb);
-      port.set({}, function(err) {
         assert.instanceOf(err, Error);
         done();
       });
@@ -320,13 +439,6 @@ describe('SerialPort', function () {
       var port = new SerialPort('/dev/exists', function() {
         expect(port.fd).to.equal(0);
         port.flush(done);
-      });
-    });
-
-    it('set should consider 0 to be a valid fd', function(done) {
-      var port = new SerialPort('/dev/exists', function() {
-        expect(port.fd).to.equal(0);
-        port.set({}, done);
       });
     });
 


### PR DESCRIPTION
We had ambiguous behavior and documentation around these settings and functions, this preserves all of the previous behavior and defines it in documentation and tests. This is a step towards separating out and cleaning up user supplied options to the constructor.