### PR TITLE
Fix double open and times when we don't close file descriptors for unix

### DIFF
--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -131,9 +131,6 @@ void EIO_Open(uv_work_t* req) {
   OpenBaton* data = static_cast<OpenBaton*>(req->data);
 
   int flags = (O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC | O_SYNC);
-  if(data->hupcl == false) {
-    flags &= ~HUPCL;
-  }
   int fd = open(data->path, flags);
 
   if(-1 == setup(fd, data)){
@@ -325,7 +322,9 @@ int setup(int fd, OpenBaton *data) {
 
   options.c_cflag |= CLOCAL; //ignore status lines
   options.c_cflag |= CREAD;  //enable receiver
-  options.c_cflag |= HUPCL;  //drop DTR (i.e. hangup) on close
+  if(data->hupcl) {
+    options.c_cflag |= HUPCL;  //drop DTR (i.e. hangup) on close
+  }
 
   // Raw output
   options.c_oflag = 0;

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -131,6 +131,9 @@ void EIO_Open(uv_work_t* req) {
   OpenBaton* data = static_cast<OpenBaton*>(req->data);
 
   int flags = (O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC | O_SYNC);
+  if(data->hupcl == false) {
+    flags &= ~HUPCL;
+  }
   int fd = open(data->path, flags);
 
   if(-1 == setup(fd, data)){
@@ -171,20 +174,6 @@ int setup(int fd, OpenBaton *data) {
     snprintf(data->errorString, sizeof(data->errorString), "Invalid data bits setting %d", data->dataBits);
     return -1;
   }
-
-
-  // int flags = (O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC | O_SYNC);
-  // if(data->hupcl == false) {
-  //   flags &= ~HUPCL;
-  // }
-  // int fd = open(data->path, flags);
-
-  int flags = (O_RDWR | O_NOCTTY | O_NONBLOCK | O_CLOEXEC | O_SYNC);
-  if(data->hupcl == false) {
-    flags &= ~HUPCL;
-  }
-  fd = open(data->path, flags);
-
 
   if (fd == -1) {
     snprintf(data->errorString, sizeof(data->errorString), "Cannot open %s", data->path);


### PR DESCRIPTION
 - includes #670 from @gfcittolin
 - includes patch from @pabigot moving when we apply HUPCL
 - Close the fd if we have any errors during setup
 - Properly receive errors when setting a custom baud rate on OS X

