### PR TITLE
Fixes 100% cpu when serial ports disconnect on windows

### DIFF
--- a/src/serialport_win.cpp
+++ b/src/serialport_win.cpp
@@ -378,6 +378,7 @@ void EIO_Write(uv_work_t* req) {
 		if(lastError != ERROR_IO_PENDING) {
 		  // Write operation error
 		  ErrorCodeToString("Writing to COM port (WriteFile)", lastError, data->errorString);
+		  return;
 		}
 		else {
 		  // Write operation is asynchronous and is pending
@@ -390,6 +391,7 @@ void EIO_Write(uv_work_t* req) {
 			// Write operation error
 			DWORD lastError = GetLastError();
 			ErrorCodeToString("Writing to COM port (GetOverlappedResult)", lastError, data->errorString);
+			return;
 		  }
 		  else {
 			// Write operation completed asynchronously


### PR DESCRIPTION
 - Fix a small memory leak
 - includes return on errors from @paulkaplan's #632
 - some linting for whitespace and indentation

[Looks better hiding whitespace changes](https://github.com/voodootikigod/node-serialport/compare/windows-error-handling?w=1)