### PR TITLE
Put all builds in /build/{Release,Debug}/ 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,6 @@
 build/
 node_modules
 npm-debug.log
-Makefile.gyp
-*.Makefile
-*.target.gyp.mk
-out
 gyp-mac-tool
 .node_pre_gyprc
 /.idea
-*.node

--- a/.npmignore
+++ b/.npmignore
@@ -1,16 +1,13 @@
-arduinoTest/
-examples/
-hwtest/
-sandbox/
-test/
-test_mocks/
+.github
 .jshintrc
 .travis.yml
-AUTHORS
 appveyor.yml
+AUTHORS.md
 changelog.md
 Gruntfile.js
 publish-binaries.md
+examples/
+test/
 
 # MIRRORED FROM .gitignore PLEASE MAINTAIN
 .lock-wscript
@@ -19,11 +16,6 @@ publish-binaries.md
 build/
 node_modules
 npm-debug.log
-Makefile.gyp
-*.Makefile
-*.target.gyp.mk
-out
 gyp-mac-tool
 .node_pre_gyprc
 /.idea
-*.node

--- a/binding.gyp
+++ b/binding.gyp
@@ -46,17 +46,6 @@
           }
         ],
       ],
-    },
-    {
-      "target_name": "action_after_build",
-      "type": "none",
-      "dependencies": [ "<(module_name)" ],
-      "copies": [
-        {
-          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
-          "destination": "<(module_path)"
-        }
-      ]
     }
   ],
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "binary": {
     "module_name": "serialport",
-    "module_path": "./out/{configuration}/",
+    "module_path": "build/{configuration}/",
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz",
     "host": "https://github.com/voodootikigod/node-serialport/releases/download/2.0.7-beta4"
   },


### PR DESCRIPTION
closes #736 

Another commit to cleanup our ignore files as they used to ignore a lot of legacy build artifacts.