### PR TITLE
Make the output of .list undefined if it’s an empty string

### DIFF
--- a/src/serialport.cpp
+++ b/src/serialport.cpp
@@ -171,7 +171,7 @@ void EIO_AfterOpen(uv_work_t* req) {
 }
 
 NAN_METHOD(Update) {
-  
+
   // file descriptor
   if(!info[0]->IsInt32()) {
     Nan::ThrowTypeError("First argument must be an int");
@@ -461,16 +461,52 @@ void EIO_AfterList(uv_work_t* req) {
     int i = 0;
     for(std::list<ListResultItem*>::iterator it = data->results.begin(); it != data->results.end(); ++it, i++) {
       v8::Local<v8::Object> item = Nan::New<v8::Object>();
-      Nan::Set(item, Nan::New<v8::String>("comName").ToLocalChecked(), Nan::New<v8::String>((*it)->comName.c_str()).ToLocalChecked());
-      Nan::Set(item, Nan::New<v8::String>("manufacturer").ToLocalChecked(), Nan::New<v8::String>((*it)->manufacturer.c_str()).ToLocalChecked());
-      Nan::Set(item, Nan::New<v8::String>("serialNumber").ToLocalChecked(), Nan::New<v8::String>((*it)->serialNumber.c_str()).ToLocalChecked());
-      Nan::Set(item, Nan::New<v8::String>("pnpId").ToLocalChecked(), Nan::New<v8::String>((*it)->pnpId.c_str()).ToLocalChecked());
-      Nan::Set(item, Nan::New<v8::String>("locationId").ToLocalChecked(), Nan::New<v8::String>((*it)->locationId.c_str()).ToLocalChecked());
-      Nan::Set(item, Nan::New<v8::String>("vendorId").ToLocalChecked(), Nan::New<v8::String>((*it)->vendorId.c_str()).ToLocalChecked());
-      Nan::Set(item, Nan::New<v8::String>("productId").ToLocalChecked(), Nan::New<v8::String>((*it)->productId.c_str()).ToLocalChecked());
+
+      if (strlen((*it)->comName.c_str()) > 0) {
+        Nan::Set(item, Nan::New<v8::String>("comName").ToLocalChecked(), Nan::New<v8::String>((*it)->comName.c_str()).ToLocalChecked());
+      } else {
+        Nan::Set(item, Nan::New<v8::String>("comName").ToLocalChecked(), Nan::Undefined());
+      }
+
+      if (strlen((*it)->manufacturer.c_str()) > 0) {
+        Nan::Set(item, Nan::New<v8::String>("manufacturer").ToLocalChecked(), Nan::New<v8::String>((*it)->manufacturer.c_str()).ToLocalChecked());
+      } else {
+        Nan::Set(item, Nan::New<v8::String>("manufacturer").ToLocalChecked(), Nan::Undefined());
+      }
+
+      if (strlen((*it)->serialNumber.c_str()) > 0) {
+        Nan::Set(item, Nan::New<v8::String>("serialNumber").ToLocalChecked(), Nan::New<v8::String>((*it)->serialNumber.c_str()).ToLocalChecked());
+      } else {
+        Nan::Set(item, Nan::New<v8::String>("serialNumber").ToLocalChecked(), Nan::Undefined());
+      }
+
+      if (strlen((*it)->pnpId.c_str()) > 0) {
+        Nan::Set(item, Nan::New<v8::String>("pnpId").ToLocalChecked(), Nan::New<v8::String>((*it)->pnpId.c_str()).ToLocalChecked());
+      } else {
+        Nan::Set(item, Nan::New<v8::String>("pnpId").ToLocalChecked(), Nan::Undefined());
+      }
+
+      if (strlen((*it)->locationId.c_str()) > 0) {
+        Nan::Set(item, Nan::New<v8::String>("locationId").ToLocalChecked(), Nan::New<v8::String>((*it)->locationId.c_str()).ToLocalChecked());
+      } else {
+        Nan::Set(item, Nan::New<v8::String>("locationId").ToLocalChecked(), Nan::Undefined());
+      }
+
+      if (strlen((*it)->vendorId.c_str()) > 0) {
+        Nan::Set(item, Nan::New<v8::String>("vendorId").ToLocalChecked(), Nan::New<v8::String>((*it)->vendorId.c_str()).ToLocalChecked());
+      } else {
+        Nan::Set(item, Nan::New<v8::String>("vendorId").ToLocalChecked(), Nan::Undefined());
+      }
+
+      if (strlen((*it)->productId.c_str()) > 0) {
+        Nan::Set(item, Nan::New<v8::String>("productId").ToLocalChecked(), Nan::New<v8::String>((*it)->productId.c_str()).ToLocalChecked());
+      } else {
+        Nan::Set(item, Nan::New<v8::String>("productId").ToLocalChecked(), Nan::Undefined());
+      }
+
       Nan::Set(results, i, item);
     }
-    argv[0] = Nan::Undefined();
+    argv[0] = Nan::Null();
     argv[1] = results;
   }
   data->callback->Call(2, argv);

--- a/src/serialport_unix.cpp
+++ b/src/serialport_unix.cpp
@@ -1,4 +1,3 @@
-#ifndef WIN32
 #include "serialport.h"
 #include "serialport_poller.h"
 #include <unistd.h>
@@ -635,21 +634,21 @@ static stDeviceListItem* GetSerialDevices()
 #endif
 
 void EIO_List(uv_work_t* req) {
-  // This code exists in javascript for unix platforms
+  ListBaton* data = static_cast<ListBaton*>(req->data);
 
-#ifdef __APPLE__
-  if(!lockInitialised)
-  {
+#ifndef __APPLE__
+  // This code exists in javascript for unix platforms
+  snprintf(data->errorString, sizeof(data->errorString), "List is not Implemented");
+  return;
+# else
+  if(!lockInitialised) {
     uv_mutex_init(&list_mutex);
     lockInitialised = TRUE;
   }
 
-  ListBaton* data = static_cast<ListBaton*>(req->data);
-
   stDeviceListItem* devices = GetSerialDevices();
 
-  if (*(devices->length) > 0)
-  {
+  if (*(devices->length) > 0) {
     stDeviceListItem* next = devices;
 
     for (int i = 0, len = *(devices->length); i < len; i++) {
@@ -735,5 +734,3 @@ void EIO_Drain(uv_work_t* req) {
 
   data->result = tcdrain(data->fd);
 }
-
-#endif

--- a/test/serialport-bindings.js
+++ b/test/serialport-bindings.js
@@ -1,0 +1,55 @@
+'use strict';
+
+var assert = require('chai').assert;
+var SerialPortBinding = require('bindings')('serialport.node');
+
+var platform;
+switch (process.platform) {
+  case 'win32':
+    platform = 'win32';
+    break;
+  case 'darwin':
+    platform = 'darwin';
+    break;
+  default:
+    platform = 'unix';
+}
+
+describe('SerialPortBinding', function () {
+  describe('.list', function () {
+    if (platform === 'unix') {
+      describe('on unix', function() {
+        it('throws an error', function(done) {
+          SerialPortBinding.list(function(err) {
+            assert.instanceOf(err, Error);
+            done();
+          });
+        });
+      });
+      return;
+    }
+    describe('on windows and darwin', function() {
+      it('returns an array', function(done) {
+        SerialPortBinding.list(function(err, data) {
+          assert.isNull(err);
+          assert.isArray(data);
+          done();
+        });
+      });
+
+      it('has objects with undefined when there is no data', function(done) {
+        SerialPortBinding.list(function(err, data) {
+          assert.isNull(err);
+          assert.isArray(data);
+          assert.isAtLeast(data.length, 1);
+          var obj = data[0];
+          Object.keys(obj).forEach(function(key) {
+            assert.notEqual(obj[key], '', 'empty values should be undefined');
+            assert.isNotNull(obj[key], 'empty values should be undefined');
+          });
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
 - Fixes #735 
 - Add some tests to start defining the bindings.

There has to be a better way to do the empty string checking.