### PR TITLE
Test on latest versions of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-os:
-- linux
-- osx
-# turn on new container-based infrastructure
+---
 sudo: false
 language: cpp
 addons:
@@ -12,18 +9,24 @@ addons:
     - g++-4.8
     - g++-4.8-multilib
     - gcc-multilib
+
+# Build matrix
+os:
+- linux
+- osx
 env:
-  matrix:
-  - TRAVIS_NODE_VERSION="0.10"
-  - TRAVIS_NODE_VERSION="0.12"
-  - TRAVIS_NODE_VERSION="4"
-  - TRAVIS_NODE_VERSION="5"
-  - TRAVIS_NODE_VERSION="0.10" ARCH="x86"
-  - TRAVIS_NODE_VERSION="0.12" ARCH="x86"
-  - TRAVIS_NODE_VERSION="4" ARCH="x86"
-  - TRAVIS_NODE_VERSION="5" ARCH="x86"
   global:
   - secure: nFQKlcfG1rV/kQm1EJtgQyRefZb6scdn/9epEaJgAyaqDRXHSZIFSuoOh4d/P5GC6V0yi6dA8I+XJsoRy29qG+JXWxN2enwjp16IbpUri9Z5H8uZPur1N6QPby9BX+PX5/4HU+KRgWtFDdfqqzbLmObXsxIUGtZtBbRY9otiUt8=
+  matrix:
+  - TRAVIS_NODE_VERSION="0.10"
+  - TRAVIS_NODE_VERSION="0.10" ARCH="x86"
+  - TRAVIS_NODE_VERSION="0.12"
+  - TRAVIS_NODE_VERSION="0.12" ARCH="x86"
+  - TRAVIS_NODE_VERSION="4"
+  - TRAVIS_NODE_VERSION="4" ARCH="x86"
+  - TRAVIS_NODE_VERSION="5"
+  - TRAVIS_NODE_VERSION="5" ARCH="x86"
+matrix:
   exclude:
   - os: osx
     env: TRAVIS_NODE_VERSION="0.10" ARCH="x86"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ environment:
   matrix:
   - nodejs_version: "0.10"
   - nodejs_version: "0.12"
-  - nodejs_version: "4.2"
-  - nodejs_version: "5.1"
+  - nodejs_version: "4.3"
+  - nodejs_version: "5.10"
 
 platform:
   - x86


### PR DESCRIPTION
 - Appveryor won’t build `5` or `4` it needs the minor number specified so we have to be specific
 - Appveyor also wont build `4.4` for unknown reasons
 - Node 6 isn't on nvm yet, so we can't easily test against it.
 - ~~Travis won’t exclude the x86 builds opened https://github.com/travis-ci/travis-ci/issues/5877 to try to fix it (vs x64)~~

This hasn't completely solved #744 but I'm going to close it for now.