### PR TITLE
Isolate the bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,13 +76,16 @@ install:
 
 script:
 # test our module
-- node serialport.js
+- node ./
 - npm test
+
 # if publishing, do it
 - if [[ $PUBLISH_BINARY == true ]]; then node-pre-gyp package; fi;
 - if [[ $PUBLISH_BINARY == true ]]; then node-pre-gyp-github publish --release; fi;
+
 # cleanup
 - node-pre-gyp clean
 - node-gyp clean
+
 # test binary exists
 - if [[ $PUBLISH_BINARY == true ]]; then npm install --fallback-to-build=false; fi;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,7 @@ build_script:
   - cmd: npm install --build-from-source --msvs_version=2013
 
 test_script:
+  - cmd: node ./
   - cmd: npm test
 
 on_success:

--- a/lib/bindings.js
+++ b/lib/bindings.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var bindings = require('bindings')('serialport.node');
+var listUnix = require('./list-unix');
+
+var linux = process.platform !== 'win32' && process.platform !== 'darwin';
+
+function listLinux(callback) {
+  callback = callback || function(err) {
+    if (err) { this.emit('error', err) }
+  }.bind(this);
+  return listUnix(callback);
+};
+
+var platformOptions = {};
+if (process.platform !== 'win32') {
+  platformOptions = {
+    vmin: 1,
+    vtime: 0
+  };
+}
+
+module.exports = {
+  close: bindings.close,
+  drain: bindings.drain,
+  flush: bindings.flush,
+  list: linux ? listLinux : bindings.list,
+  open: bindings.open,
+  SerialportPoller: bindings.SerialportPoller,
+  set: bindings.set,
+  update: bindings.update,
+  write: bindings.write,
+  platformOptions: platformOptions
+};

--- a/lib/serialport.js
+++ b/lib/serialport.js
@@ -13,9 +13,8 @@ var debug = require('debug')('serialport');
 var assign = require('object.assign').getPolyfill();
 
 // Internal Dependencies
-var SerialPortBinding = require('bindings')('serialport.node');
-var parsers = require('./lib/parsers');
-var listUnix = require('./lib/list-unix');
+var SerialPortBinding = require('./bindings');
+var parsers = require('./parsers');
 
 // Built-ins Dependencies
 var EventEmitter = require('events').EventEmitter;
@@ -26,16 +25,7 @@ var util = require('util');
 // Setup the factory
 var factory = new EventEmitter();
 factory.parsers = parsers;
-if (process.platform === 'win32' || process.platform === 'darwin') {
-  factory.list = SerialPortBinding.list;
-} else {
-  factory.list = function(callback) {
-    callback = callback || function(err) {
-      if (err) { this.emit('error', err) }
-    }.bind(this);
-    return listUnix(callback);
-  };
-}
+factory.list = SerialPortBinding.list;
 
 //  VALIDATION ARRAYS
 var DATABITS = [5, 6, 7, 8];
@@ -47,17 +37,6 @@ var SET_OPTIONS = ['brk', 'cts', 'dtr', 'dts', 'rts'];
 // Stuff from ReadStream, refactored for our usage:
 var kPoolSize = 40 * 1024;
 var kMinPoolSpace = 128;
-
-function makeDefaultPlatformOptions() {
-  var options = {};
-
-  if (process.platform !== 'win32') {
-    options.vmin = 1;
-    options.vtime = 0;
-  }
-
-  return options;
-}
 
 var defaultSettings = {
   baudRate: 9600,
@@ -71,7 +50,7 @@ var defaultSettings = {
   stopBits: 1,
   bufferSize: 64 * 1024,
   parser: parsers.raw,
-  platformOptions: makeDefaultPlatformOptions()
+  platformOptions: SerialPortBinding.platformOptions
 };
 
 var defaultSetFlags = {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz",
     "host": "https://github.com/voodootikigod/node-serialport/releases/download/2.1.0"
   },
-  "main": "./serialport",
+  "main": "./lib/serialport",
   "repository": {
     "type": "git",
     "url": "git://github.com/voodootikigod/node-serialport.git"

--- a/test/arduinoTest/serialDuplexTest.js
+++ b/test/arduinoTest/serialDuplexTest.js
@@ -7,7 +7,7 @@ Tests the functionality of the serial port library.
 To be used in conjunction with the Arduino sketch ArduinoEcho.ino
 */
 'use strict';
-var SerialPort = require('../../serialport').SerialPort;
+var SerialPort = require('../../').SerialPort;
 var optimist = require('optimist');
 
 var args = optimist

--- a/test/arduinoTest/stress.js
+++ b/test/arduinoTest/stress.js
@@ -4,7 +4,7 @@
 
 var assert = require('chai').assert;
 var util = require('util');
-var serialPort = require('../../serialport');
+var serialPort = require('../../');
 require('colors'); // this modifies String.prototype
 // var fs = require('fs');
 

--- a/test/mocks/darwin-hardware.js
+++ b/test/mocks/darwin-hardware.js
@@ -37,15 +37,15 @@ var Hardware = function () {
   this.fds = {};
   this.ports = {};
   this.mockBinding = {
+    close: this.close.bind(this),
+    drain: this.drain.bind(this),
+    flush: this.flush.bind(this),
     list: this.list.bind(this),
     open: this.open.bind(this),
-    update: this.update.bind(this),
-    write: this.write.bind(this),
-    close: this.close.bind(this),
-    flush: this.flush.bind(this),
+    SerialportPoller: mockSerialportPoller(this),
     set: this.set.bind(this),
-    drain: this.drain.bind(this),
-    SerialportPoller: mockSerialportPoller(this)
+    update: this.update.bind(this),
+    write: this.write.bind(this)
   };
 };
 
@@ -191,15 +191,12 @@ var hardware = new Hardware();
 
 var SandboxedModule = require('sandboxed-module');
 
-var serialPort = SandboxedModule.require('../../serialport', {
+var serialPort = SandboxedModule.require('../../', {
   requires: {
     fs: {
       read: hardware.fakeRead.bind(hardware)
     },
-    'bindings': function() {
-      return hardware.mockBinding;
-    },
-    'mock-binding': hardware.mockBinding
+    './bindings': hardware.mockBinding
   },
   singleOnly: true,
   globals: {

--- a/test/serialport-integration.js
+++ b/test/serialport-integration.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assert = require('chai').assert;
-var serialPort = require('../serialport');
+var serialPort = require('../');
 var SerialPort = serialPort.SerialPort;
 
 describe('SerialPort', function () {


### PR DESCRIPTION
 - Test requiring the library as part of the build processes on all platforms
 - move all the easy stuff into ./lib/bindings the rest will bring breaking changes probably
 - move all js code into ./lib
