### PR TITLE
Drop some dependencies for a smaller bundle size

### DIFF
--- a/lib/list-unix.js
+++ b/lib/list-unix.js
@@ -1,8 +1,25 @@
 'use strict';
-var Promise = require('bluebird');
-var childProcess = Promise.promisifyAll(require('child_process'));
-var fs = Promise.promisifyAll(require('fs'));
+var Promise = require('es6-promise').Promise;
+var childProcess = require('child_process');
+var fs = require('fs');
 var path = require('path');
+
+function promisify(func) {
+  return function(arg) {
+    return new Promise(function(resolve, reject) {
+      func(arg, function(err, data) {
+        if (err) {
+          return reject(err);
+        }
+        resolve(data);
+      });
+    });
+  };
+}
+
+var statAsync = promisify(fs.stat);
+var readdirAsync = promisify(fs.readdir);
+var execAsync = promisify(childProcess.exec);
 
 function udevParser(output) {
   var udevInfo = output.split('\n').reduce(function(info, line) {
@@ -51,19 +68,19 @@ function checkPathAndDevice(path) {
   if (!(/(tty(S|ACM|USB|AMA|MFD)|rfcomm)/).test(path)) {
     return false;
   }
-  return fs.statAsync(path).then(function(stats) {
+  return statAsync(path).then(function(stats) {
     return stats.isCharacterDevice();
   });
 }
 
 function lookupPort(file) {
   var udevadm = 'udevadm info --query=property -p $(udevadm info -q path -n ' + file + ')';
-  return childProcess.execAsync(udevadm).then(udevParser);
+  return execAsync(udevadm).then(udevParser);
 }
 
 function listUnix(callback) {
   var dirName = '/dev';
-  fs.readdirAsync(dirName)
+  readdirAsync(dirName)
     .catch(function(err) {
       // if this directory is not found we just pretend everything is OK
       // TODO Depreciated this check?
@@ -72,10 +89,10 @@ function listUnix(callback) {
       }
       throw err;
     })
-    .map(function(file) { return path.join(dirName, file) })
-    .filter(checkPathAndDevice)
-    .map(lookupPort)
-    .asCallback(callback);
+    .then(function(data) { return data.map(function(file) { return path.join(dirName, file) }) })
+    .then(function(data) { return Promise.all(data.filter(checkPathAndDevice)) })
+    .then(function(data) { return Promise.all(data.map(lookupPort)) })
+    .then(function(data) { callback(null, data) }, function(err) { callback(err) });
 }
 
 module.exports = listUnix;

--- a/package.json
+++ b/package.json
@@ -50,11 +50,10 @@
   ],
   "dependencies": {
     "bindings": "1.2.1",
-    "bluebird": "^3.3.5",
     "debug": "^2.1.1",
+    "es6-promise": "^3.1.2",
     "nan": "~2.2.1",
     "node-pre-gyp": "^0.6.26",
-    "node-pre-gyp-github": "^1.1.0",
     "object.assign": "^4.0.3",
     "optimist": "~0.6.1",
     "sf": "0.1.7"
@@ -69,13 +68,13 @@
     "grunt-mocha-test": "^0.12.7",
     "gruntify-eslint": "^2.0.0",
     "mocha": "^2.4.5",
+    "node-pre-gyp-github": "^1.1.2",
     "sandboxed-module": "^2.0.3",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"
   },
   "bundledDependencies": [
-    "node-pre-gyp",
-    "node-pre-gyp-github"
+    "node-pre-gyp"
   ],
   "engines": {
     "node": ">= 0.10.0"
@@ -87,7 +86,7 @@
   "license": "MIT",
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",
-    "rebuild": "npm rebuild && node-pre-gyp rebuild",
+    "rebuild-all": "npm rebuild && node-pre-gyp rebuild",
     "stress": "mocha --no-timeouts test/arduinoTest/stress.js",
     "grunt": "grunt",
     "test": "grunt --verbose"


### PR DESCRIPTION
 - Drop `bluebird` 168kb for `es6-promise` 37.1kb (vs 18.1kb library code) bundled sizes
 - Move `node-pre-gyp-github` to dev deps so it's not always installed (5.8MB package size)
 - Stop bundling `node-pre-gyp-github` as it's only needed during publishing