### PR TITLE
Avoid deprecation warnings

### DIFF
--- a/src/serialport_poller.cpp
+++ b/src/serialport_poller.cpp
@@ -61,12 +61,10 @@ void SerialportPoller::Init(Handle<Object> target) {
   // Prototype
 
   // SerialportPoller.close()
-  Nan::SetPrototypeTemplate(tpl, "close",
-      Nan::GetFunction(Nan::New<FunctionTemplate>(Close)).ToLocalChecked());
+  Nan::SetPrototypeMethod(tpl, "close", Close);
 
   // SerialportPoller.start()
-  Nan::SetPrototypeTemplate(tpl, "start",
-      Nan::GetFunction(Nan::New<FunctionTemplate>(Start)).ToLocalChecked());
+  Nan::SetPrototypeMethod(tpl, "start", Start);
 
   serialportpoller_constructor.Reset(tpl);
 


### PR DESCRIPTION
This should solve deprecation message issue #722. Tested on a Raspberry Pi with Node.js v0.10.29 and Node.js v6.0.0.