### PR TITLE
Disable instruction sets when building for linux on ia32 for Galileo support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -3,7 +3,7 @@
     {
       'target_name': 'serialport',
       'sources': [
-        'src/serialport.cpp',
+        'src/serialport.cpp'
       ],
       'include_dirs': [
         '<!(node -e "require(\'nan\')")'
@@ -14,38 +14,27 @@
             'sources': [
               'src/serialport_win.cpp',
               'src/win/disphelper.c',
-              'src/win/enumser.cpp',
+              'src/win/enumser.cpp'
             ],
             'msvs_settings': {
               'VCCLCompilerTool': {
                 'ExceptionHandling': '2',
                 'DisableSpecificWarnings': [ '4530', '4506' ],
-              },
-            },
-          },
-        ],
-        ['OS=="mac"',
-          {
-            'sources': [
-              'src/serialport_unix.cpp',
-              'src/serialport_poller.cpp',
-            ],
-            'xcode_settings': {
-              'OTHER_LDFLAGS': [
-                '-framework CoreFoundation -framework IOKit'
-              ]
+              }
             }
           }
         ],
         ['OS!="win"',
-          {
-            'sources': [
-              'src/serialport_unix.cpp',
-              'src/serialport_poller.cpp',
-            ],
-          }
+          {'sources': ['src/serialport_unix.cpp', 'src/serialport_poller.cpp']}
         ],
-      ],
+        # Disable SIMD instruction sets for boards like Galileo
+        ['"<!(node -p "process.platform + process.arch")"=="linuxia32"',
+          {'cflags': ['-mno-sse', '-mno-mmx']}
+        ],
+        ['OS=="mac"',
+          {'xcode_settings': {'OTHER_LDFLAGS': ['-framework CoreFoundation -framework IOKit']}}
+        ]
+      ]
     }
-  ],
+  ]
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+Version 3.1.2-beta1
+-------------
+ - Test for galileo prebuilt binaries
+
 Version 3.1.1
 -------------
  - fix an issue with bundled deps for node-pre-gyp on npm

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "serialport",
-  "version": "3.1.1",
+  "name": "serialport-galileo-test",
+  "version": "3.1.2-beta1",
   "description": "Node.js package to access serial ports. Welcome your robotic javascript overlords. Better yet, program them!",
   "author": {
     "name": "Chris Williams",
@@ -10,7 +10,7 @@
   "binary": {
     "module_name": "serialport",
     "module_path": "build/{configuration}/",
-    "host": "https://github.com/voodootikigod/node-serialport/releases/download/3.1.1"
+    "host": "https://github.com/voodootikigod/node-serialport/releases/download/3.1.2-beta1"
   },
   "main": "./lib/serialport",
   "repository": {


### PR DESCRIPTION
Per #747 some of the intel boards don't support some instructions and our prebuilt binaries wont run on those platforms. This PR disables a few instruction sets for 32bit linux installations. If these instructions are available but disabled it's a performance hit, if they're not available but enabled they cause an annoying error with little information. I don't have data for what kind of performance hit. I'm actually just assuming.

We can do one of a few things.
- Not provide prebuilt binaries for linux/ia32 (It's pretty heavily downloaded see the issue for counts)
- Do what this PR does and disable the instructions for everybody
- Something better

cc @rwaldron @jacobrosenthal @fivdi 