### PR TITLE
Build precompiled binary for Node.js 4.4 on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
   matrix:
   - nodejs_version: "0.10"
   - nodejs_version: "0.12"
-  - nodejs_version: "4.3"
+  - nodejs_version: "4.4"
   - nodejs_version: "5.11"
   - nodejs_version: "6.0"
 


### PR DESCRIPTION
Build pre-compiled binary for Node.js 4.4 on Windows instead of 4.3, now that 4.4.3 is the LTS version.
