### PR TITLE
Modify Linux ia32 compile options for Galileo 2

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -29,7 +29,7 @@
         ],
         # Disable SIMD instruction sets for boards like Galileo
         ['"<!(node -p "process.platform + process.arch")"=="linuxia32"',
-          {'cflags': ['-mno-sse', '-mno-mmx']}
+          {'cflags': ['-march=pentium', '-mtune=pentium']}
         ],
         ['OS=="mac"',
           {'xcode_settings': {'OTHER_LDFLAGS': ['-framework CoreFoundation -framework IOKit']}}


### PR DESCRIPTION
This is a 2nd attempt at getting pre-compiled ia32 binaries for Linux to function on the Galileo 2.