### PR TITLE
unbundle node-pre-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,9 +75,6 @@
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"
   },
-  "bundledDependencies": [
-    "node-pre-gyp"
-  ],
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
This is probably unnecessary and can easily cause issues we'll test it in beta to be sure.

There's a small chance that if you have an app with other dependencies that use node-pre-gyp that sometime it wont be available when the install scripts expect it to be. I haven't been able to reproduce it with the latest npm 2 or 3.